### PR TITLE
Implement TileJSON validation

### DIFF
--- a/src/app/js/src/SampleApp.jsx
+++ b/src/app/js/src/SampleApp.jsx
@@ -18,6 +18,8 @@ import { Grid, Row, Col } from 'react-flexbox-grid';
 import FlatButton from 'material-ui/FlatButton';
 import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar';
 
+import { validate } from 'tilejson-validator';
+
 import gistRequest from '../data/request.json';
 import {
     changeTileJson,
@@ -161,8 +163,19 @@ class App extends Component {
             }));
             return;
         }
+        for (let i = 0; i < tileJSON.length; i += 1) {
+            if (!validate(tileJSON[i])) {
+                const objectName = tileJSON[i].name ? tileJSON[i].name : i + 1;
+                this.props.dispatch(changeTileJSONParseError({
+                    tileJSONParseError: `Input object ${objectName} is not a valid TileJSON.`,
+                }));
+                this.props.dispatch(toggleErrorSnackbarOpen({
+                    errorSnackbarOpen: true,
+                }));
+                return;
+            }
+        }
         for (let i = 0; i < this.layers.length; i += 1) {
-            // TODO: Validate tileJSON[i] using tilejson-validator
             if (this.layers[i] !== baseLayer) {
                 map.removeLayer(this.layers[i]);
             }
@@ -194,6 +207,9 @@ class App extends Component {
         const shareSnackbarMessage = (
             <a className="snackbarLink" href={this.props.shareLink}>{this.props.shareLink}</a>
         );
+        const errorSnackbarStyle = {
+            backgroundColor: '#fd4582',
+        };
         let sideBar;
         if (this.props.isCollapsed) {
             const styleWhiteText = {
@@ -272,6 +288,7 @@ class App extends Component {
                             open={this.props.errorSnackbarOpen}
                             message={this.props.tileJSONParseError}
                             onRequestClose={this.handleErrorSbRequestClose}
+                            bodyStyle={errorSnackbarStyle}
                         />
                         <AddLayerDialog
                             addLayer={this.addLayer}

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -37,7 +37,8 @@
     "redux": "3.5.2",
     "redux-devtools": "3.3.1",
     "redux-logger": "2.6.1",
-    "redux-thunk": "2.1.0"
+    "redux-thunk": "2.1.0",
+    "tilejson-validator": "0.1.5"
   },
   "devDependencies": {
     "autoprefixer": "6.7.4",

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -12,6 +12,10 @@
   dependencies:
     "@mapbox/point-geometry" "~0.1.0"
 
+"JSV@>= 4.0.x":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
+
 abbrev@1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.0.tgz#d0554c2256636e2f56e7c2e5ad183f859428d81f"
@@ -135,6 +139,10 @@ ansi-styles@^3.1.0:
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
     color-convert "^1.9.0"
+
+ansi-styles@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
 
 ansicolors@~0.2.1:
   version "0.2.1"
@@ -1181,6 +1189,14 @@ chalk@^2.1.0:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"
     supports-color "^4.0.0"
+
+chalk@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
+  dependencies:
+    ansi-styles "~1.0.0"
+    has-color "~0.1.0"
+    strip-ansi "~0.1.0"
 
 change-case@2.3.x:
   version "2.3.1"
@@ -2880,6 +2896,10 @@ has-binary@0.1.7:
   dependencies:
     isarray "0.0.1"
 
+has-color@~0.1.0:
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
+
 has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
@@ -3571,6 +3591,13 @@ json5@^0.5.0, json5@^0.5.1:
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
+
+jsonlint-lines@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/jsonlint-lines/-/jsonlint-lines-1.7.1.tgz#507de680d3fb8c4be1641cc57d6f679f29f178ff"
+  dependencies:
+    JSV ">= 4.0.x"
+    nomnom ">= 1.5.x"
 
 jsonpointer@^4.0.0:
   version "4.0.1"
@@ -4344,6 +4371,13 @@ node-sass@4.5.3:
     request "^2.79.0"
     sass-graph "^2.1.1"
     stdout-stream "^1.4.0"
+
+"nomnom@>= 1.5.x":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
+  dependencies:
+    chalk "~0.4.0"
+    underscore "~1.6.0"
 
 "nopt@2 || 3":
   version "3.0.6"
@@ -6199,6 +6233,10 @@ strip-ansi@^4.0.0:
   dependencies:
     ansi-regex "^3.0.0"
 
+strip-ansi@~0.1.0:
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
+
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -6395,6 +6433,12 @@ thunky@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-0.1.0.tgz#bf30146824e2b6e67b0f2d7a4ac8beb26908684e"
 
+tilejson-validator@0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/tilejson-validator/-/tilejson-validator-0.1.5.tgz#e392d020ad2390d64711d0b4e9c2419a0866530b"
+  dependencies:
+    jsonlint-lines "1.7.1"
+
 time-stamp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357"
@@ -6558,6 +6602,10 @@ underscore-template-loader@0.7.3:
 underscore@1.8.3, underscore@>=1.8.3:
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+
+underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
 
 uniq@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Overview

This PR adds validation of user inputted TileJSON using the `tilejson-validator` npm package.

Connects #4 

### Demo

Illegal TileJSON

![screen shot 2017-10-05 at 8 32 32 am](https://user-images.githubusercontent.com/3959096/31227464-ed4dc858-a9a7-11e7-99cb-7ce3f3b1710d.png)

<img width="960" alt="screen shot 2017-10-05 at 8 32 52 am" src="https://user-images.githubusercontent.com/3959096/31227472-f49636ea-a9a7-11e7-9243-363c38f77ab6.png">

Legal TileJSON

![screen shot 2017-10-05 at 8 33 14 am](https://user-images.githubusercontent.com/3959096/31227478-fbd3ebd2-a9a7-11e7-8778-faf6688868c5.png)


## Testing Instructions

 * Pull branch and run locally
 * Try entering illegal TileJSON in the textarea. 
 * Try entering legal TileJSON.
