### PR TITLE
Make dev server accessible when not on localhost

### DIFF
--- a/src/app/webpack.common.config.js
+++ b/src/app/webpack.common.config.js
@@ -118,6 +118,7 @@ module.exports = {
         fs: 'empty',
     },
     devServer: {
+        disableHostCheck: true,
         historyApiFallback: {
             index: '/',
         }


### PR DESCRIPTION
## Overview

Turning off this setting allows for the site to be accessed when it is not running on your local machine.

## Testing Instructions

- Run the dev server and try to access it via computer-name.internal.azavea.com:port.
