### PR TITLE
Fix map height when sidebar is collapsed

### DIFF
--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -143,7 +143,12 @@ class App extends Component {
                 <div>
                     <Row>
                         {bar}
-                        <Col xs={this.props.isCollapsed ? 12 : 8} id="map" className="map" />
+                        <Col
+                            xs={this.props.isCollapsed ? 12 : 8}
+                            id="map"
+                            className={this.props.isCollapsed ?
+                                'map mapExpanded' : 'map mapCollapsed'}
+                        />
                         <Snackbar
                             open={this.props.shareSnackbarOpen}
                             message={shareSnackbarMessage}

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -23,8 +23,15 @@ html, body, #root, [data-reactroot], [data-reactroot] > div {
 }
 
 #map {
-    max-height: 100%;
     padding: 0 !important;
+}
+
+.mapCollapsed {
+    max-height: 100%;
+}
+
+.mapExpanded {
+    max-height: calc(100% - 56px);
 }
 
 #jsonTextarea {


### PR DESCRIPTION
## Overview

The attribution on the bottom right of the map was being hidden when the sidebar was collapsed. To fix this, I'm controlling the height of the map with a different CSS class when it is in its expanded state versus when it is in its collapsed state. 

Connects #38 

## Testing Instructions

 * Pull, build, run 
 * Check to see that attribution is visible on collapsing sidebar 
