### PR TITLE
Add layer boxes to sidebar

### DIFF
--- a/src/app/js/src/AddLayerDialog.jsx
+++ b/src/app/js/src/AddLayerDialog.jsx
@@ -1,9 +1,6 @@
 import React, { Component } from 'react';
-import { arrayOf, bool, func, object, string } from 'prop-types';
+import { bool, func, string } from 'prop-types';
 import { connect } from 'react-redux';
-
-import TileLayer from 'ol/layer/tile';
-import XYZ from 'ol/source/xyz';
 
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
@@ -12,9 +9,7 @@ import TextField from 'material-ui/TextField';
 import {
     changeLayerName,
     changeLayerUrl,
-    changeTileJson,
     toggleAddLayerDialog,
-    addLayer,
 } from './actions';
 
 class AddLayerDialog extends Component {
@@ -22,8 +17,8 @@ class AddLayerDialog extends Component {
         super(props);
         this.changeName = this.changeName.bind(this);
         this.changeUrl = this.changeUrl.bind(this);
-        this.addLayer = this.addLayer.bind(this);
         this.closeAddLayerDialog = this.closeAddLayerDialog.bind(this);
+        this.addOnKeyDown = this.addOnKeyDown.bind(this);
     }
 
     changeName(e) {
@@ -44,50 +39,10 @@ class AddLayerDialog extends Component {
         }));
     }
 
-    addLayer() {
-        if (this.props.url === '') {
-            return;
+    addOnKeyDown(e) {
+        if (e.keyCode === 13) {
+            this.props.addLayer();
         }
-        const newLayer = new TileLayer({
-            source: new XYZ({
-                url: this.props.url,
-            }),
-        });
-        const layerNum = this.props.addLayer(newLayer);
-        const layerName = (this.props.name === '' ? `Layer ${layerNum - 1}` : this.props.name);
-        const newTileJSON = {
-            tilejson: '2.2.0',
-            name: layerName,
-            version: '1.0.0',
-            scheme: 'xyz',
-            tiles: [
-                this.props.url,
-            ],
-        };
-        this.props.dispatch(addLayer({
-            newLayer: {
-                name: layerName,
-                url: this.props.url,
-                tileJSON: newTileJSON,
-            },
-        }));
-        const tileJSONList = this.props.tileJSON;
-        tileJSONList.push(newTileJSON);
-        this.props.dispatch(changeTileJson({
-            tileJSON: tileJSONList,
-        }));
-        if (document.getElementById('jsonTextarea')) {
-            document.getElementById('jsonTextarea').value = JSON.stringify(tileJSONList, null, '\t');
-        }
-        this.props.dispatch(toggleAddLayerDialog({
-            showAddLayerDialog: false,
-        }));
-        this.props.dispatch(changeLayerName({
-            name: '',
-        }));
-        this.props.dispatch(changeLayerUrl({
-            url: '',
-        }));
     }
 
     render() {
@@ -99,7 +54,7 @@ class AddLayerDialog extends Component {
             <FlatButton
                 label="Add"
                 primary
-                onClick={this.addLayer}
+                onClick={this.props.addLayer}
             />,
         ];
         return (
@@ -111,8 +66,20 @@ class AddLayerDialog extends Component {
                     open={this.props.showAddLayerDialog}
                     onRequestClose={this.closeAddLayerDialog}
                 >
-                    <TextField hintText="Layer Name" fullWidth onChange={this.changeName} value={this.props.name} />
-                    <TextField hintText="Tile URL" fullWidth onChange={this.changeUrl} value={this.props.url} />
+                    <TextField
+                        hintText="Layer Name"
+                        fullWidth
+                        onChange={this.changeName}
+                        value={this.props.name}
+                        onKeyDown={this.addOnKeyDown}
+                    />
+                    <TextField
+                        hintText="Tile URL"
+                        fullWidth
+                        onChange={this.changeUrl}
+                        value={this.props.url}
+                        onKeyDown={this.addOnKeyDown}
+                    />
                 </Dialog>
             </div>
         );
@@ -124,7 +91,6 @@ AddLayerDialog.propTypes = {
     addLayer: func.isRequired,
     name: string.isRequired,
     url: string.isRequired,
-    tileJSON: arrayOf(object).isRequired,
     showAddLayerDialog: bool.isRequired,
 };
 

--- a/src/app/js/src/AddLayerDialog.jsx
+++ b/src/app/js/src/AddLayerDialog.jsx
@@ -14,6 +14,7 @@ import {
     changeLayerUrl,
     changeTileJson,
     toggleAddLayerDialog,
+    addLayer,
 } from './actions';
 
 class AddLayerDialog extends Component {
@@ -63,6 +64,12 @@ class AddLayerDialog extends Component {
                 this.props.url,
             ],
         };
+        this.props.dispatch(addLayer({
+            newLayer: {
+                name: layerName,
+                url: this.props.url,
+            },
+        }));
         const tileJSONList = this.props.tileJSON;
         tileJSONList.push(newTileJSON);
         this.props.dispatch(changeTileJson({

--- a/src/app/js/src/AddLayerDialog.jsx
+++ b/src/app/js/src/AddLayerDialog.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { bool, func, string } from 'prop-types';
+import { bool, func, number, string } from 'prop-types';
 import { connect } from 'react-redux';
 
 import Dialog from 'material-ui/Dialog';
@@ -10,6 +10,7 @@ import {
     changeLayerName,
     changeLayerUrl,
     toggleAddLayerDialog,
+    toggleEditLayerDialog,
 } from './actions';
 
 class AddLayerDialog extends Component {
@@ -18,7 +19,9 @@ class AddLayerDialog extends Component {
         this.changeName = this.changeName.bind(this);
         this.changeUrl = this.changeUrl.bind(this);
         this.closeAddLayerDialog = this.closeAddLayerDialog.bind(this);
+        this.closeEditLayerDialog = this.closeEditLayerDialog.bind(this);
         this.addOnKeyDown = this.addOnKeyDown.bind(this);
+        this.editLayer = this.editLayer.bind(this);
     }
 
     changeName(e) {
@@ -39,31 +42,50 @@ class AddLayerDialog extends Component {
         }));
     }
 
+    closeEditLayerDialog() {
+        this.props.dispatch(toggleEditLayerDialog({
+            showEditLayerDialog: false,
+        }));
+    }
+
     addOnKeyDown(e) {
         if (e.keyCode === 13) {
-            this.props.addLayer();
+            if (this.props.editMode) {
+                this.props.editLayer(this.props.editLayerId);
+            } else {
+                this.props.addLayer();
+            }
         }
+    }
+
+    editLayer() {
+        this.props.editLayer(this.props.editLayerId);
     }
 
     render() {
         const actions = [
             <FlatButton
                 label="Cancel"
-                onClick={this.closeAddLayerDialog}
+                onClick={this.props.editMode ?
+                    this.closeEditLayerDialog :
+                    this.closeAddLayerDialog}
             />,
             <FlatButton
-                label="Add"
+                label={this.props.editMode ? 'Save' : 'Add'}
                 primary
-                onClick={this.props.addLayer}
+                onClick={this.props.editMode ? this.editLayer : this.props.addLayer}
             />,
         ];
+        const title = this.props.editMode ? 'Edit Layer' : 'Add Layer';
         return (
             <div>
                 <Dialog
-                    title="Add Layer"
+                    title={title}
                     actions={actions}
                     modal={false}
-                    open={this.props.showAddLayerDialog}
+                    open={this.props.editMode ?
+                        this.props.showEditLayerDialog :
+                        this.props.showAddLayerDialog}
                     onRequestClose={this.closeAddLayerDialog}
                 >
                     <TextField
@@ -88,10 +110,14 @@ class AddLayerDialog extends Component {
 
 AddLayerDialog.propTypes = {
     dispatch: func.isRequired,
-    addLayer: func.isRequired,
     name: string.isRequired,
     url: string.isRequired,
     showAddLayerDialog: bool.isRequired,
+    showEditLayerDialog: bool.isRequired,
+    editMode: bool.isRequired,
+    editLayerId: number.isRequired,
+    addLayer: func,
+    editLayer: func,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/AddLayerDialog.jsx
+++ b/src/app/js/src/AddLayerDialog.jsx
@@ -68,6 +68,7 @@ class AddLayerDialog extends Component {
             newLayer: {
                 name: layerName,
                 url: this.props.url,
+                tileJSON: newTileJSON,
             },
         }));
         const tileJSONList = this.props.tileJSON;

--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -15,6 +15,7 @@ import {
     toggleShareSnackbarOpen,
     toggleErrorSnackbarOpen,
     toggleAddLayerDialog,
+    removeLayer,
 } from './actions';
 import {
     baseLayer,
@@ -39,6 +40,7 @@ class App extends Component {
         this.openAddLayerDialog = this.openAddLayerDialog.bind(this);
         this.addLayer = this.addLayer.bind(this);
         this.removeLayers = this.removeLayers.bind(this);
+        this.removeLayer = this.removeLayer.bind(this);
     }
 
     componentDidMount() {
@@ -60,6 +62,14 @@ class App extends Component {
         this.layers = [
             baseLayer,
         ];
+    }
+
+    removeLayer(i) {
+        map.removeLayer(this.layers[i + 1]);
+        this.layers.splice(i + 1, 1);
+        this.props.dispatch(removeLayer({
+            i,
+        }));
     }
 
     clearLayers() {
@@ -135,6 +145,7 @@ class App extends Component {
                     clearLayers={this.clearLayers}
                     addLayer={this.addLayer}
                     removeLayers={this.removeLayers}
+                    removeLayer={this.removeLayer}
                 />
             );
         }

--- a/src/app/js/src/LayerBox.jsx
+++ b/src/app/js/src/LayerBox.jsx
@@ -26,6 +26,7 @@ class LayerBox extends Component {
         this.expandDetails = this.expandDetails.bind(this);
         this.collapseSource = this.collapseSource.bind(this);
         this.expandSource = this.expandSource.bind(this);
+        this.removeLayer = this.removeLayer.bind(this);
     }
 
     collapseDetails() {
@@ -54,6 +55,10 @@ class LayerBox extends Component {
             i: this.props.i,
             sourceView: true,
         }));
+    }
+
+    removeLayer() {
+        this.props.removeLayer(this.props.i);
     }
 
     render() {
@@ -145,7 +150,11 @@ class LayerBox extends Component {
                         <IconButton iconStyle={smallIcon} touch disabled>
                             <EditorModeEditIcon />
                         </IconButton>
-                        <IconButton iconStyle={smallIcon} touch disabled>
+                        <IconButton
+                            iconStyle={smallIcon}
+                            onClick={this.removeLayer}
+                            touch
+                        >
                             <ActionDeleteIcon />
                         </IconButton>
                         <IconButton
@@ -174,6 +183,7 @@ LayerBox.propTypes = {
     viewDetail: bool.isRequired,
     viewSource: bool.isRequired,
     layerTileJSON: shape({}).isRequired,
+    removeLayer: func.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/LayerBox.jsx
+++ b/src/app/js/src/LayerBox.jsx
@@ -17,6 +17,7 @@ import { Grid, Row, Col } from 'react-flexbox-grid';
 
 import {
     toggleLayerBoxInfo,
+    toggleEditLayerDialog,
 } from './actions';
 
 class LayerBox extends Component {
@@ -27,6 +28,7 @@ class LayerBox extends Component {
         this.collapseSource = this.collapseSource.bind(this);
         this.expandSource = this.expandSource.bind(this);
         this.removeLayer = this.removeLayer.bind(this);
+        this.openEditLayerDialog = this.openEditLayerDialog.bind(this);
     }
 
     collapseDetails() {
@@ -59,6 +61,13 @@ class LayerBox extends Component {
 
     removeLayer() {
         this.props.removeLayer(this.props.i);
+    }
+
+    openEditLayerDialog() {
+        this.props.dispatch(toggleEditLayerDialog({
+            showEditLayerDialog: true,
+            i: this.props.i,
+        }));
     }
 
     render() {
@@ -147,7 +156,11 @@ class LayerBox extends Component {
                         <ToolbarTitle style={fontSize11} text={this.props.layerName} />
                     </ToolbarGroup>
                     <ToolbarGroup>
-                        <IconButton iconStyle={smallIcon} touch disabled>
+                        <IconButton
+                            iconStyle={smallIcon}
+                            onClick={this.openEditLayerDialog}
+                            touch
+                        >
                             <EditorModeEditIcon />
                         </IconButton>
                         <IconButton

--- a/src/app/js/src/LayerBox.jsx
+++ b/src/app/js/src/LayerBox.jsx
@@ -1,0 +1,137 @@
+import React, { Component } from 'react';
+import { bool, func, number, string } from 'prop-types';
+import { connect } from 'react-redux';
+
+import IconButton from 'material-ui/IconButton';
+import NavigationExpandMoreIcon from 'material-ui/svg-icons/navigation/expand-more';
+import NavigationExpandLessIcon from 'material-ui/svg-icons/navigation/expand-less';
+import ActionCodeIcon from 'material-ui/svg-icons/action/code';
+import ActionDeleteIcon from 'material-ui/svg-icons/action/delete';
+import EditorModeEditIcon from 'material-ui/svg-icons/editor/mode-edit';
+import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar';
+import Paper from 'material-ui/Paper';
+
+import { Grid, Row, Col } from 'react-flexbox-grid';
+
+import {
+    toggleLayerBoxDetails,
+} from './actions';
+
+class LayerBox extends Component {
+    constructor(props) {
+        super(props);
+        this.collapseDetails = this.collapseDetails.bind(this);
+        this.expandDetails = this.expandDetails.bind(this);
+    }
+
+    collapseDetails() {
+        this.props.dispatch(toggleLayerBoxDetails({
+            i: this.props.i,
+            detailView: false,
+        }));
+    }
+
+    expandDetails() {
+        this.props.dispatch(toggleLayerBoxDetails({
+            i: this.props.i,
+            detailView: true,
+        }));
+    }
+
+    render() {
+        const smallIcon = {
+            width: 18,
+            height: 18,
+            color: '#8b8b8b',
+        };
+        let details;
+        let expandOrCollapseButton = (
+            <IconButton
+                iconStyle={smallIcon}
+                onClick={this.expandDetails}
+                touch
+            >
+                <NavigationExpandMoreIcon />
+            </IconButton>
+        );
+        if (this.props.viewDetail) {
+            details = (
+                <Grid fluid>
+                    <br />
+                    <Row>
+                        <Col xs={3}>
+                            Name
+                        </Col>
+                        <Col xs={9}>
+                            <div className="detailValue">
+                                {this.props.layerName}
+                            </div>
+                        </Col>
+                    </Row>
+                    <br />
+                    <Row>
+                        <Col xs={3}>
+                            URL
+                        </Col>
+                        <Col xs={9}>
+                            <div className="detailValue">
+                                {this.props.layerUrl}
+                            </div>
+                        </Col>
+                    </Row>
+                    <br />
+                </Grid>
+            );
+            expandOrCollapseButton = (
+                <IconButton
+                    iconStyle={smallIcon}
+                    onClick={this.collapseDetails}
+                    touch
+                >
+                    <NavigationExpandLessIcon />
+                </IconButton>
+            );
+        }
+        return (
+            <Paper zDepth={1}>
+                <Toolbar>
+                    <ToolbarGroup>
+                        <ToolbarTitle style={{ fontSize: '11pt' }} text={this.props.layerName} />
+                    </ToolbarGroup>
+                    <ToolbarGroup>
+                        <IconButton iconStyle={smallIcon} touch disabled>
+                            <ActionCodeIcon />
+                        </IconButton>
+                        <IconButton iconStyle={smallIcon} touch disabled>
+                            <EditorModeEditIcon />
+                        </IconButton>
+                        <IconButton iconStyle={smallIcon} touch disabled>
+                            <ActionDeleteIcon />
+                        </IconButton>
+                        {expandOrCollapseButton}
+                    </ToolbarGroup>
+                </Toolbar>
+                {details}
+            </Paper>
+        );
+    }
+}
+
+LayerBox.propTypes = {
+    dispatch: func.isRequired,
+    layerName: string.isRequired,
+    layerUrl: string.isRequired,
+    i: number.isRequired,
+    // layers: arrayOf(shape({
+    //     name: string.isRequired,
+    //     url: string.isRequired,
+    //     detailView: bool.isRequired,
+    // })).isRequired,
+    viewDetail: bool.isRequired,
+};
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+export default connect(mapStateToProps)(LayerBox);

--- a/src/app/js/src/LayerBox.jsx
+++ b/src/app/js/src/LayerBox.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { bool, func, number, string } from 'prop-types';
+import { bool, func, number, shape, string } from 'prop-types';
 import { connect } from 'react-redux';
 
 import IconButton from 'material-ui/IconButton';
@@ -11,10 +11,12 @@ import EditorModeEditIcon from 'material-ui/svg-icons/editor/mode-edit';
 import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar';
 import Paper from 'material-ui/Paper';
 
+import ReactJson from 'react-json-view';
+
 import { Grid, Row, Col } from 'react-flexbox-grid';
 
 import {
-    toggleLayerBoxDetails,
+    toggleLayerBoxInfo,
 } from './actions';
 
 class LayerBox extends Component {
@@ -22,19 +24,35 @@ class LayerBox extends Component {
         super(props);
         this.collapseDetails = this.collapseDetails.bind(this);
         this.expandDetails = this.expandDetails.bind(this);
+        this.collapseSource = this.collapseSource.bind(this);
+        this.expandSource = this.expandSource.bind(this);
     }
 
     collapseDetails() {
-        this.props.dispatch(toggleLayerBoxDetails({
+        this.props.dispatch(toggleLayerBoxInfo({
             i: this.props.i,
             detailView: false,
         }));
     }
 
     expandDetails() {
-        this.props.dispatch(toggleLayerBoxDetails({
+        this.props.dispatch(toggleLayerBoxInfo({
             i: this.props.i,
             detailView: true,
+        }));
+    }
+
+    collapseSource() {
+        this.props.dispatch(toggleLayerBoxInfo({
+            i: this.props.i,
+            sourceView: false,
+        }));
+    }
+
+    expandSource() {
+        this.props.dispatch(toggleLayerBoxInfo({
+            i: this.props.i,
+            sourceView: true,
         }));
     }
 
@@ -43,6 +61,16 @@ class LayerBox extends Component {
             width: 18,
             height: 18,
             color: '#8b8b8b',
+        };
+        const fontSize11 = {
+            fontSize: '11pt',
+        };
+        const fontSize9 = {
+            fontSize: '9pt',
+        };
+        const sourceStyle = {
+            fontSize: '9pt',
+            backgroundColor: '#f7f7f7',
         };
         let details;
         let expandOrCollapseButton = (
@@ -56,7 +84,7 @@ class LayerBox extends Component {
         );
         if (this.props.viewDetail) {
             details = (
-                <Grid fluid>
+                <Grid style={fontSize9} fluid>
                     <br />
                     <Row>
                         <Col xs={3}>
@@ -92,26 +120,47 @@ class LayerBox extends Component {
                 </IconButton>
             );
         }
+        let source;
+        if (this.props.viewSource) {
+            source = (
+                <Grid style={sourceStyle} className="detailValue" fluid>
+                    <br />
+                    <ReactJson
+                        name={false}
+                        src={this.props.layerTileJSON}
+                        displayObjectSize={false}
+                        indentWidth={2}
+                    />
+                    <br />
+                </Grid>
+            );
+        }
         return (
-            <Paper zDepth={1}>
+            <Paper zDepth={1} style={{ overflow: 'hidden' }}>
                 <Toolbar>
                     <ToolbarGroup>
-                        <ToolbarTitle style={{ fontSize: '11pt' }} text={this.props.layerName} />
+                        <ToolbarTitle style={fontSize11} text={this.props.layerName} />
                     </ToolbarGroup>
                     <ToolbarGroup>
-                        <IconButton iconStyle={smallIcon} touch disabled>
-                            <ActionCodeIcon />
-                        </IconButton>
                         <IconButton iconStyle={smallIcon} touch disabled>
                             <EditorModeEditIcon />
                         </IconButton>
                         <IconButton iconStyle={smallIcon} touch disabled>
                             <ActionDeleteIcon />
                         </IconButton>
+                        <IconButton
+                            onClick={this.props.viewSource ?
+                                this.collapseSource : this.expandSource}
+                            iconStyle={smallIcon}
+                            touch
+                        >
+                            <ActionCodeIcon />
+                        </IconButton>
                         {expandOrCollapseButton}
                     </ToolbarGroup>
                 </Toolbar>
                 {details}
+                {source}
             </Paper>
         );
     }
@@ -122,12 +171,9 @@ LayerBox.propTypes = {
     layerName: string.isRequired,
     layerUrl: string.isRequired,
     i: number.isRequired,
-    // layers: arrayOf(shape({
-    //     name: string.isRequired,
-    //     url: string.isRequired,
-    //     detailView: bool.isRequired,
-    // })).isRequired,
     viewDetail: bool.isRequired,
+    viewSource: bool.isRequired,
+    layerTileJSON: shape({}).isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/LayerBoxes.jsx
+++ b/src/app/js/src/LayerBoxes.jsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import { arrayOf, number, object } from 'prop-types';
+import { connect } from 'react-redux';
+
+import LayerBox from './LayerBox';
+
+class LayerBoxes extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        const layerBoxes = this.props.layers.map((layer, i) =>
+            <div key={i.toString()}>
+                <LayerBox
+                    i={i}
+                    layerName={layer.name}
+                    layerUrl={layer.url}
+                    viewDetail={i === this.props.layerDetail}
+                />
+                <br />
+            </div>,
+        );
+        return (
+            <div>
+                {layerBoxes}
+            </div>
+        );
+    }
+}
+
+LayerBoxes.propTypes = {
+    layers: arrayOf(object).isRequired,
+    layerDetail: number.isRequired,
+};
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+export default connect(mapStateToProps)(LayerBoxes);

--- a/src/app/js/src/LayerBoxes.jsx
+++ b/src/app/js/src/LayerBoxes.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { arrayOf, number, object } from 'prop-types';
+import { arrayOf, object } from 'prop-types';
 import { connect } from 'react-redux';
 
 import LayerBox from './LayerBox';
@@ -17,7 +17,9 @@ class LayerBoxes extends Component {
                     i={i}
                     layerName={layer.name}
                     layerUrl={layer.url}
-                    viewDetail={i === this.props.layerDetail}
+                    viewDetail={layer.detailView}
+                    viewSource={layer.sourceView}
+                    layerTileJSON={layer.tileJSON}
                 />
                 <br />
             </div>,
@@ -32,7 +34,6 @@ class LayerBoxes extends Component {
 
 LayerBoxes.propTypes = {
     layers: arrayOf(object).isRequired,
-    layerDetail: number.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/LayerBoxes.jsx
+++ b/src/app/js/src/LayerBoxes.jsx
@@ -1,8 +1,9 @@
 import React, { Component } from 'react';
-import { arrayOf, object } from 'prop-types';
+import { arrayOf, func, object } from 'prop-types';
 import { connect } from 'react-redux';
 
 import LayerBox from './LayerBox';
+import QuickAddLayerBox from './QuickAddLayerBox';
 
 class LayerBoxes extends Component {
     constructor(props) {
@@ -20,12 +21,17 @@ class LayerBoxes extends Component {
                     viewDetail={layer.detailView}
                     viewSource={layer.sourceView}
                     layerTileJSON={layer.tileJSON}
+                    removeLayer={this.props.removeLayer}
                 />
                 <br />
             </div>,
         );
         return (
             <div>
+                <QuickAddLayerBox
+                    addLayer={this.props.addLayer}
+                />
+                <br />
                 {layerBoxes}
             </div>
         );
@@ -33,6 +39,8 @@ class LayerBoxes extends Component {
 }
 
 LayerBoxes.propTypes = {
+    addLayer: func.isRequired,
+    removeLayer: func.isRequired,
     layers: arrayOf(object).isRequired,
 };
 

--- a/src/app/js/src/QuickAddLayerBox.jsx
+++ b/src/app/js/src/QuickAddLayerBox.jsx
@@ -1,29 +1,22 @@
 import React, { Component } from 'react';
-import { arrayOf, func, object, string } from 'prop-types';
+import { func, string } from 'prop-types';
 import { connect } from 'react-redux';
 
 import IconButton from 'material-ui/IconButton';
 import ContentAddIcon from 'material-ui/svg-icons/content/add';
-import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
+import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar';
 import Paper from 'material-ui/Paper';
 import TextField from 'material-ui/TextField';
 
-import TileLayer from 'ol/layer/tile';
-import XYZ from 'ol/source/xyz';
-
 import {
     changeLayerUrl,
-    changeLayerName,
-    changeTileJson,
-    toggleAddLayerDialog,
-    addLayer,
 } from './actions';
 
 class QuickAddLayerBox extends Component {
     constructor(props) {
         super(props);
         this.changeUrl = this.changeUrl.bind(this);
-        this.addLayer = this.addLayer.bind(this);
+        this.quickAddOnKeyDown = this.quickAddOnKeyDown.bind(this);
     }
 
     changeUrl(e) {
@@ -32,50 +25,10 @@ class QuickAddLayerBox extends Component {
         }));
     }
 
-    addLayer() {
-        if (this.props.url === '') {
-            return;
+    quickAddOnKeyDown(e) {
+        if (e.keyCode === 13) {
+            this.props.addLayer();
         }
-        const newLayer = new TileLayer({
-            source: new XYZ({
-                url: this.props.url,
-            }),
-        });
-        const layerNum = this.props.addLayer(newLayer);
-        const layerName = `Layer ${layerNum - 1}`;
-        const newTileJSON = {
-            tilejson: '2.2.0',
-            name: layerName,
-            version: '1.0.0',
-            scheme: 'xyz',
-            tiles: [
-                this.props.url,
-            ],
-        };
-        this.props.dispatch(addLayer({
-            newLayer: {
-                name: layerName,
-                url: this.props.url,
-                tileJSON: newTileJSON,
-            },
-        }));
-        const tileJSONList = this.props.tileJSON;
-        tileJSONList.push(newTileJSON);
-        this.props.dispatch(changeTileJson({
-            tileJSON: tileJSONList,
-        }));
-        if (document.getElementById('jsonTextarea')) {
-            document.getElementById('jsonTextarea').value = JSON.stringify(tileJSONList, null, '\t');
-        }
-        this.props.dispatch(toggleAddLayerDialog({
-            showAddLayerDialog: false,
-        }));
-        this.props.dispatch(changeLayerName({
-            name: '',
-        }));
-        this.props.dispatch(changeLayerUrl({
-            url: '',
-        }));
     }
 
     render() {
@@ -91,15 +44,17 @@ class QuickAddLayerBox extends Component {
             <Paper zDepth={1} style={{ overflow: 'hidden' }}>
                 <Toolbar>
                     <ToolbarGroup>
+                        <ToolbarTitle style={fontSize11} text="Quick Add" />
                         <TextField
                             style={fontSize11}
-                            hintText="Add Tile URL"
+                            hintText="Tile URL"
                             onChange={this.changeUrl}
                             value={this.props.url}
+                            onKeyDown={this.quickAddOnKeyDown}
                         />
                     </ToolbarGroup>
                     <ToolbarGroup>
-                        <IconButton iconStyle={smallIcon} onClick={this.addLayer} touch>
+                        <IconButton iconStyle={smallIcon} onClick={this.props.addLayer} touch>
                             <ContentAddIcon />
                         </IconButton>
                     </ToolbarGroup>
@@ -113,7 +68,6 @@ QuickAddLayerBox.propTypes = {
     dispatch: func.isRequired,
     addLayer: func.isRequired,
     url: string.isRequired,
-    tileJSON: arrayOf(object).isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/QuickAddLayerBox.jsx
+++ b/src/app/js/src/QuickAddLayerBox.jsx
@@ -1,0 +1,123 @@
+import React, { Component } from 'react';
+import { arrayOf, func, object, string } from 'prop-types';
+import { connect } from 'react-redux';
+
+import IconButton from 'material-ui/IconButton';
+import ContentAddIcon from 'material-ui/svg-icons/content/add';
+import { Toolbar, ToolbarGroup } from 'material-ui/Toolbar';
+import Paper from 'material-ui/Paper';
+import TextField from 'material-ui/TextField';
+
+import TileLayer from 'ol/layer/tile';
+import XYZ from 'ol/source/xyz';
+
+import {
+    changeLayerUrl,
+    changeLayerName,
+    changeTileJson,
+    toggleAddLayerDialog,
+    addLayer,
+} from './actions';
+
+class QuickAddLayerBox extends Component {
+    constructor(props) {
+        super(props);
+        this.changeUrl = this.changeUrl.bind(this);
+        this.addLayer = this.addLayer.bind(this);
+    }
+
+    changeUrl(e) {
+        this.props.dispatch(changeLayerUrl({
+            url: e.target.value,
+        }));
+    }
+
+    addLayer() {
+        if (this.props.url === '') {
+            return;
+        }
+        const newLayer = new TileLayer({
+            source: new XYZ({
+                url: this.props.url,
+            }),
+        });
+        const layerNum = this.props.addLayer(newLayer);
+        const layerName = `Layer ${layerNum - 1}`;
+        const newTileJSON = {
+            tilejson: '2.2.0',
+            name: layerName,
+            version: '1.0.0',
+            scheme: 'xyz',
+            tiles: [
+                this.props.url,
+            ],
+        };
+        this.props.dispatch(addLayer({
+            newLayer: {
+                name: layerName,
+                url: this.props.url,
+                tileJSON: newTileJSON,
+            },
+        }));
+        const tileJSONList = this.props.tileJSON;
+        tileJSONList.push(newTileJSON);
+        this.props.dispatch(changeTileJson({
+            tileJSON: tileJSONList,
+        }));
+        if (document.getElementById('jsonTextarea')) {
+            document.getElementById('jsonTextarea').value = JSON.stringify(tileJSONList, null, '\t');
+        }
+        this.props.dispatch(toggleAddLayerDialog({
+            showAddLayerDialog: false,
+        }));
+        this.props.dispatch(changeLayerName({
+            name: '',
+        }));
+        this.props.dispatch(changeLayerUrl({
+            url: '',
+        }));
+    }
+
+    render() {
+        const smallIcon = {
+            width: 18,
+            height: 18,
+            color: '#8b8b8b',
+        };
+        const fontSize11 = {
+            fontSize: '11pt',
+        };
+        return (
+            <Paper zDepth={1} style={{ overflow: 'hidden' }}>
+                <Toolbar>
+                    <ToolbarGroup>
+                        <TextField
+                            style={fontSize11}
+                            hintText="Add Tile URL"
+                            onChange={this.changeUrl}
+                            value={this.props.url}
+                        />
+                    </ToolbarGroup>
+                    <ToolbarGroup>
+                        <IconButton iconStyle={smallIcon} onClick={this.addLayer} touch>
+                            <ContentAddIcon />
+                        </IconButton>
+                    </ToolbarGroup>
+                </Toolbar>
+            </Paper>
+        );
+    }
+}
+
+QuickAddLayerBox.propTypes = {
+    dispatch: func.isRequired,
+    addLayer: func.isRequired,
+    url: string.isRequired,
+    tileJSON: arrayOf(object).isRequired,
+};
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+export default connect(mapStateToProps)(QuickAddLayerBox);

--- a/src/app/js/src/SideBar.jsx
+++ b/src/app/js/src/SideBar.jsx
@@ -150,7 +150,10 @@ class SideBar extends Component {
             sideBarItems = (
                 <div>
                     <br />
-                    <LayerBoxes />
+                    <LayerBoxes
+                        addLayer={this.props.addLayer}
+                        removeLayer={this.props.removeLayer}
+                    />
                 </div>
             );
         }
@@ -182,6 +185,7 @@ SideBar.propTypes = {
     dispatch: func.isRequired,
     addLayer: func.isRequired,
     removeLayers: func.isRequired,
+    removeLayer: func.isRequired,
     openAddLayerDialog: func.isRequired,
     share: func.isRequired,
     clearLayers: func.isRequired,

--- a/src/app/js/src/SideBar.jsx
+++ b/src/app/js/src/SideBar.jsx
@@ -121,23 +121,11 @@ class SideBar extends Component {
     }
 
     render() {
-        return (
-            <Col xs={4} id="menu">
-                <AppBar title="TileJSON.io" iconElementLeft={<IconButton onClick={this.collapse}><ExpandLess /></IconButton>} />
-                <Grid fluid>
-                    <br />
-                    <Row>
-                        <Col xs={4}>
-                            <FlatButton onClick={this.props.openAddLayerDialog} label="Add" primary fullWidth />
-                        </Col>
-                        <Col xs={4}>
-                            <FlatButton onClick={this.props.share} label="Share" primary fullWidth />
-                        </Col>
-                        <Col xs={4}>
-                            <FlatButton onClick={this.props.clearLayers} label="Clear" primary fullWidth />
-                        </Col>
-                    </Row>
-                    <br />
+        const sideBarFunction = 1;
+        let sideBarItems;
+        if (sideBarFunction === 0) {
+            sideBarItems = (
+                <div>
                     <TextField
                         id="jsonTextarea"
                         multiLine
@@ -156,9 +144,34 @@ class SideBar extends Component {
                         fullWidth
                         primary
                     />
-                    <br />
+                </div>
+            );
+        } else if (sideBarFunction === 1) {
+            sideBarItems = (
+                <div>
                     <br />
                     <LayerBoxes />
+                </div>
+            );
+        }
+        return (
+            <Col xs={4} id="menu">
+                <AppBar title="TileJSON.io" iconElementLeft={<IconButton onClick={this.collapse}><ExpandLess /></IconButton>} />
+                <Grid fluid>
+                    <br />
+                    <Row>
+                        <Col xs={4}>
+                            <FlatButton onClick={this.props.openAddLayerDialog} label="Add" primary fullWidth />
+                        </Col>
+                        <Col xs={4}>
+                            <FlatButton onClick={this.props.share} label="Share" primary fullWidth />
+                        </Col>
+                        <Col xs={4}>
+                            <FlatButton onClick={this.props.clearLayers} label="Clear" primary fullWidth />
+                        </Col>
+                    </Row>
+                    <br />
+                    {sideBarItems}
                 </Grid>
             </Col>
         );

--- a/src/app/js/src/SideBar.jsx
+++ b/src/app/js/src/SideBar.jsx
@@ -15,6 +15,8 @@ import { Grid, Row, Col } from 'react-flexbox-grid';
 
 import { validate } from 'tilejson-validator';
 
+import LayerBoxes from './LayerBoxes';
+
 import {
     changeTileJson,
     changeTileJSONParseError,
@@ -154,6 +156,9 @@ class SideBar extends Component {
                         fullWidth
                         primary
                     />
+                    <br />
+                    <br />
+                    <LayerBoxes />
                 </Grid>
             </Col>
         );

--- a/src/app/js/src/actions.js
+++ b/src/app/js/src/actions.js
@@ -14,6 +14,7 @@ export const TOGGLE_ADD_LAYER_DIALOG = 'TOGGLE_ADD_LAYER_DIALOG';
 
 export const ADD_LAYER = 'ADD_LAYER';
 export const TOGGLE_LAYER_BOX_INFO = 'TOGGLE_LAYER_BOX_INFO';
+export const REMOVE_LAYER = 'REMOVE_LAYER';
 
 export function changeLayerName(payload) {
     return {
@@ -101,6 +102,13 @@ export function addLayer(payload) {
 export function toggleLayerBoxInfo(payload) {
     return {
         type: TOGGLE_LAYER_BOX_INFO,
+        payload,
+    };
+}
+
+export function removeLayer(payload) {
+    return {
+        type: REMOVE_LAYER,
         payload,
     };
 }

--- a/src/app/js/src/actions.js
+++ b/src/app/js/src/actions.js
@@ -13,7 +13,7 @@ export const TOGGLE_COLLAPSE = 'TOGGLE_COLLAPSE';
 export const TOGGLE_ADD_LAYER_DIALOG = 'TOGGLE_ADD_LAYER_DIALOG';
 
 export const ADD_LAYER = 'ADD_LAYER';
-export const TOGGLE_LAYER_BOX_DETAILS = 'TOGGLE_LAYER_BOX_DETAILS';
+export const TOGGLE_LAYER_BOX_INFO = 'TOGGLE_LAYER_BOX_INFO';
 
 export function changeLayerName(payload) {
     return {
@@ -98,9 +98,9 @@ export function addLayer(payload) {
     };
 }
 
-export function toggleLayerBoxDetails(payload) {
+export function toggleLayerBoxInfo(payload) {
     return {
-        type: TOGGLE_LAYER_BOX_DETAILS,
+        type: TOGGLE_LAYER_BOX_INFO,
         payload,
     };
 }

--- a/src/app/js/src/actions.js
+++ b/src/app/js/src/actions.js
@@ -11,10 +11,14 @@ export const TOGGLE_SHARE_SNACKBAR_OPEN = 'TOGGLE_SHARE_SNACKBAR_OPEN';
 export const TOGGLE_ERROR_SNACKBAR_OPEN = 'TOGGLE_ERROR_SNACKBAR_OPEN';
 export const TOGGLE_COLLAPSE = 'TOGGLE_COLLAPSE';
 export const TOGGLE_ADD_LAYER_DIALOG = 'TOGGLE_ADD_LAYER_DIALOG';
+export const TOGGLE_EDIT_LAYER_DIALOG = 'TOGGLE_EDIT_LAYER_DIALOG';
 
 export const ADD_LAYER = 'ADD_LAYER';
 export const TOGGLE_LAYER_BOX_INFO = 'TOGGLE_LAYER_BOX_INFO';
 export const REMOVE_LAYER = 'REMOVE_LAYER';
+export const EDIT_LAYER = 'EDIT_LAYER';
+
+export const POST_ADD_EDIT_CLEAR = 'POST_ADD_EDIT_CLEAR';
 
 export function changeLayerName(payload) {
     return {
@@ -92,6 +96,13 @@ export function toggleAddLayerDialog(payload) {
     };
 }
 
+export function toggleEditLayerDialog(payload) {
+    return {
+        type: TOGGLE_EDIT_LAYER_DIALOG,
+        payload,
+    };
+}
+
 export function addLayer(payload) {
     return {
         type: ADD_LAYER,
@@ -109,6 +120,21 @@ export function toggleLayerBoxInfo(payload) {
 export function removeLayer(payload) {
     return {
         type: REMOVE_LAYER,
+        payload,
+    };
+}
+
+export function editLayer(payload) {
+    return {
+        type: EDIT_LAYER,
+        payload,
+    };
+}
+
+
+export function postAddEditClear(payload) {
+    return {
+        type: POST_ADD_EDIT_CLEAR,
         payload,
     };
 }

--- a/src/app/js/src/actions.js
+++ b/src/app/js/src/actions.js
@@ -12,6 +12,9 @@ export const TOGGLE_ERROR_SNACKBAR_OPEN = 'TOGGLE_ERROR_SNACKBAR_OPEN';
 export const TOGGLE_COLLAPSE = 'TOGGLE_COLLAPSE';
 export const TOGGLE_ADD_LAYER_DIALOG = 'TOGGLE_ADD_LAYER_DIALOG';
 
+export const ADD_LAYER = 'ADD_LAYER';
+export const TOGGLE_LAYER_BOX_DETAILS = 'TOGGLE_LAYER_BOX_DETAILS';
+
 export function changeLayerName(payload) {
     return {
         type: CHANGE_LAYER_NAME,
@@ -84,6 +87,20 @@ export function toggleCollapse(payload) {
 export function toggleAddLayerDialog(payload) {
     return {
         type: TOGGLE_ADD_LAYER_DIALOG,
+        payload,
+    };
+}
+
+export function addLayer(payload) {
+    return {
+        type: ADD_LAYER,
+        payload,
+    };
+}
+
+export function toggleLayerBoxDetails(payload) {
+    return {
+        type: TOGGLE_LAYER_BOX_DETAILS,
         payload,
     };
 }

--- a/src/app/js/src/reducers.js
+++ b/src/app/js/src/reducers.js
@@ -12,6 +12,8 @@ import {
     TOGGLE_ERROR_SNACKBAR_OPEN,
     TOGGLE_COLLAPSE,
     TOGGLE_ADD_LAYER_DIALOG,
+    ADD_LAYER,
+    TOGGLE_LAYER_BOX_DETAILS,
 } from './actions';
 
 import {
@@ -30,6 +32,8 @@ const initialState = {
     errorSnackbarOpen: false,
     isCollapsed: false,
     showAddLayerDialog: false,
+    layers: [],
+    layerDetail: -1,
 };
 
 function mainReducer(state = initialState, action) {
@@ -88,6 +92,26 @@ function mainReducer(state = initialState, action) {
             return Object.assign({}, state, {
                 showAddLayerDialog: action.payload.showAddLayerDialog,
             });
+        case ADD_LAYER: {
+            const layers = state.layers;
+            const newLayer = {
+                name: action.payload.newLayer.name,
+                url: action.payload.newLayer.url,
+                detailView: false,
+            };
+            layers.push(newLayer);
+            return Object.assign({}, state, {
+                layers,
+            });
+        }
+        case TOGGLE_LAYER_BOX_DETAILS: {
+            const layers = state.layers;
+            layers[action.payload.i].detailView = action.payload.detailView;
+            return Object.assign({}, state, {
+                layers,
+                layerDetail: action.payload.detailView ? action.payload.i : -1,
+            });
+        }
         default:
             return state;
     }

--- a/src/app/js/src/reducers.js
+++ b/src/app/js/src/reducers.js
@@ -13,7 +13,7 @@ import {
     TOGGLE_COLLAPSE,
     TOGGLE_ADD_LAYER_DIALOG,
     ADD_LAYER,
-    TOGGLE_LAYER_BOX_DETAILS,
+    TOGGLE_LAYER_BOX_INFO,
 } from './actions';
 
 import {
@@ -33,7 +33,6 @@ const initialState = {
     isCollapsed: false,
     showAddLayerDialog: false,
     layers: [],
-    layerDetail: -1,
 };
 
 function mainReducer(state = initialState, action) {
@@ -97,19 +96,30 @@ function mainReducer(state = initialState, action) {
             const newLayer = {
                 name: action.payload.newLayer.name,
                 url: action.payload.newLayer.url,
+                tileJSON: action.payload.newLayer.tileJSON,
                 detailView: false,
+                sourceView: false,
             };
             layers.push(newLayer);
             return Object.assign({}, state, {
                 layers,
             });
         }
-        case TOGGLE_LAYER_BOX_DETAILS: {
-            const layers = state.layers;
-            layers[action.payload.i].detailView = action.payload.detailView;
+        case TOGGLE_LAYER_BOX_INFO: {
+            const layers = state.layers.map((layer, i) => {
+                const newLayer = Object.assign({}, layer);
+                if (i === action.payload.i) {
+                    if (Object.hasOwnProperty.call(action.payload, 'detailView')) {
+                        newLayer.detailView = action.payload.detailView;
+                    }
+                    if (Object.hasOwnProperty.call(action.payload, 'sourceView')) {
+                        newLayer.sourceView = action.payload.sourceView;
+                    }
+                }
+                return newLayer;
+            });
             return Object.assign({}, state, {
                 layers,
-                layerDetail: action.payload.detailView ? action.payload.i : -1,
             });
         }
         default:

--- a/src/app/js/src/reducers.js
+++ b/src/app/js/src/reducers.js
@@ -14,6 +14,7 @@ import {
     TOGGLE_ADD_LAYER_DIALOG,
     ADD_LAYER,
     TOGGLE_LAYER_BOX_INFO,
+    REMOVE_LAYER,
 } from './actions';
 
 import {
@@ -62,6 +63,7 @@ function mainReducer(state = initialState, action) {
                 tileJSONEditMode: false,
                 shareSnackbarOpen: false,
                 errorSnackbarOpen: false,
+                layers: [],
             });
         case CHANGE_SHARE_LINK:
             return Object.assign({}, state, {
@@ -119,6 +121,16 @@ function mainReducer(state = initialState, action) {
                 return newLayer;
             });
             return Object.assign({}, state, {
+                layers,
+            });
+        }
+        case REMOVE_LAYER: {
+            const tileJSON = [...state.tileJSON.slice(0, action.payload.i),
+                ...state.tileJSON.slice(action.payload.i + 1)];
+            const layers = [...state.layers.slice(0, action.payload.i),
+                ...state.layers.slice(action.payload.i + 1)];
+            return Object.assign({}, state, {
+                tileJSON,
                 layers,
             });
         }

--- a/src/app/js/src/reducers.js
+++ b/src/app/js/src/reducers.js
@@ -12,9 +12,12 @@ import {
     TOGGLE_ERROR_SNACKBAR_OPEN,
     TOGGLE_COLLAPSE,
     TOGGLE_ADD_LAYER_DIALOG,
+    TOGGLE_EDIT_LAYER_DIALOG,
     ADD_LAYER,
     TOGGLE_LAYER_BOX_INFO,
     REMOVE_LAYER,
+    EDIT_LAYER,
+    POST_ADD_EDIT_CLEAR,
 } from './actions';
 
 import {
@@ -34,6 +37,8 @@ const initialState = {
     isCollapsed: false,
     showAddLayerDialog: false,
     layers: [],
+    showEditLayerDialog: false,
+    editLayerId: -1,
 };
 
 function mainReducer(state = initialState, action) {
@@ -64,6 +69,8 @@ function mainReducer(state = initialState, action) {
                 shareSnackbarOpen: false,
                 errorSnackbarOpen: false,
                 layers: [],
+                showEditLayerDialog: false,
+                editLayerId: -1,
             });
         case CHANGE_SHARE_LINK:
             return Object.assign({}, state, {
@@ -92,6 +99,15 @@ function mainReducer(state = initialState, action) {
         case TOGGLE_ADD_LAYER_DIALOG:
             return Object.assign({}, state, {
                 showAddLayerDialog: action.payload.showAddLayerDialog,
+            });
+        case TOGGLE_EDIT_LAYER_DIALOG:
+            return Object.assign({}, state, {
+                showEditLayerDialog: action.payload.showEditLayerDialog,
+                editLayerId: action.payload.i,
+                name: action.payload.showEditLayerDialog ?
+                    state.layers[action.payload.i].name : state.name,
+                url: action.payload.showEditLayerDialog ?
+                    state.layers[action.payload.i].url : state.url,
             });
         case ADD_LAYER: {
             const layers = state.layers;
@@ -134,6 +150,28 @@ function mainReducer(state = initialState, action) {
                 layers,
             });
         }
+        case EDIT_LAYER: {
+            const layers = state.layers;
+            const newLayer = {
+                name: action.payload.newLayer.name,
+                url: action.payload.newLayer.url,
+                tileJSON: action.payload.newLayer.tileJSON,
+                detailView: false,
+                sourceView: false,
+            };
+            layers[action.payload.i] = newLayer;
+            return Object.assign({}, state, {
+                layers,
+            });
+        }
+        case POST_ADD_EDIT_CLEAR:
+            return Object.assign({}, state, {
+                url: '',
+                name: '',
+                showAddLayerDialog: false,
+                showEditLayerDialog: false,
+                editLayerId: -1,
+            });
         default:
             return state;
     }

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -29,6 +29,7 @@
     "react": "15.6.1",
     "react-dom": "15.6.1",
     "react-flexbox-grid": "1.1.5",
+    "react-json-view": "1.13.1",
     "react-leaflet": "1.6.6",
     "react-leaflet-control": "1.4.0",
     "react-redux": "5.0.4",

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -42,3 +42,7 @@ html, body, #root, [data-reactroot], [data-reactroot] > div {
 .snackbarLink, .snackbarLink:hover, .snackbarLink:active {
     color: #fff;
 }
+
+.detailValue {
+    word-break: break-all;
+}

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -877,6 +877,10 @@ balanced-match@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
 
+base16@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/base16/-/base16-1.0.0.tgz#e297f60d7ec1014a7a971a39ebc8a98c0b681e70"
+
 base64-arraybuffer@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/base64-arraybuffer/-/base64-arraybuffer-0.1.2.tgz#474df4a9f2da24e05df3158c3b1db3c3cd46a154"
@@ -1313,6 +1317,14 @@ cli-usage@^0.1.1:
 cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+
+clipboard@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
 
 cliui@^2.1.0:
   version "2.1.0"
@@ -1868,6 +1880,10 @@ del@^3.0.0:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegate@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.1.3.tgz#9a8251a777d7025faa55737bc3b071742127a9fd"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -2523,7 +2539,13 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
+fbemitter@^2.0.0:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/fbemitter/-/fbemitter-2.1.1.tgz#523e14fdaf5248805bb02f62efc33be703f51865"
+  dependencies:
+    fbjs "^0.8.4"
+
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.15.tgz#4f0695fdfcc16c37c0b07facec8cb4c4091685b9"
   dependencies:
@@ -2640,6 +2662,13 @@ flatten@^1.0.2:
 flexboxgrid@^6.3.0:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/flexboxgrid/-/flexboxgrid-6.3.1.tgz#e99898afc07b7047722bb81a958a5fba4d4e20fd"
+
+flux@^3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/flux/-/flux-3.1.3.tgz#d23bed515a79a22d933ab53ab4ada19d05b2f08a"
+  dependencies:
+    fbemitter "^2.0.0"
+    fbjs "^0.8.0"
 
 follow-redirects@^1.2.3:
   version "1.2.4"
@@ -2846,6 +2875,12 @@ globule@^1.0.0:
     glob "~7.1.1"
     lodash "~4.17.4"
     minimatch "~3.0.2"
+
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
 
 graceful-fs@^4.1.2:
   version "4.1.11"
@@ -3820,6 +3855,10 @@ lodash.cond@^4.3.0:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/lodash.cond/-/lodash.cond-4.5.2.tgz#f471a1da486be60f6ab955d17115523dd1d255d5"
 
+lodash.curry@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/lodash.curry/-/lodash.curry-4.1.1.tgz#248e36072ede906501d75966200a86dab8b23170"
+
 lodash.debounce@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-3.1.1.tgz#812211c378a94cc29d5aa4e3346cf0bfce3a7df5"
@@ -3847,6 +3886,10 @@ lodash.flatten@^3.0.2:
   dependencies:
     lodash._baseflatten "^3.0.0"
     lodash._isiterateecall "^3.0.0"
+
+lodash.flow@^3.3.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.flow/-/lodash.flow-3.5.0.tgz#87bf40292b8cf83e4e8ce1a3ae4209e20071675a"
 
 lodash.get@^3.7.0:
   version "3.7.0"
@@ -5176,6 +5219,10 @@ punycode@^1.2.4, punycode@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.4.1.tgz#c0d5a63b2718800ad8e1eb0fa5269c84dd41845e"
 
+pure-color@^1.2.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/pure-color/-/pure-color-1.3.0.tgz#1fe064fb0ac851f0de61320a8bf796836422f33e"
+
 q@^1.1.2:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.0.tgz#dd01bac9d06d30e6f219aecb8253ee9ebdc308f1"
@@ -5247,6 +5294,15 @@ rc@^1.1.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-base16-styling@^0.5.3:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/react-base16-styling/-/react-base16-styling-0.5.3.tgz#3858f24e9c4dd8cbd3f702f3f74d581ca2917269"
+  dependencies:
+    base16 "^1.0.0"
+    lodash.curry "^4.0.1"
+    lodash.flow "^3.3.0"
+    pure-color "^1.2.0"
+
 react-deep-force-update@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/react-deep-force-update/-/react-deep-force-update-1.1.1.tgz#bcd31478027b64b3339f108921ab520b4313dc2c"
@@ -5275,6 +5331,15 @@ react-flexbox-grid@1.1.5:
   dependencies:
     flexboxgrid "^6.3.0"
     prop-types "^15.5.8"
+
+react-json-view@1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/react-json-view/-/react-json-view-1.13.1.tgz#2a4ec2720d959fb7440bac914dfcb90442c536a9"
+  dependencies:
+    clipboard "^1.7.1"
+    flux "^3.1.3"
+    react-base16-styling "^0.5.3"
+    react-textarea-autosize "^5.1.0"
 
 react-leaflet-control@1.4.0:
   version "1.4.0"
@@ -5333,6 +5398,12 @@ react-router@3.0.5:
     loose-envify "^1.2.0"
     prop-types "^15.5.6"
     warning "^3.0.0"
+
+react-textarea-autosize@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-5.1.0.tgz#ffbf8164fce217c79443c1c17dedf730592df224"
+  dependencies:
+    prop-types "^15.5.10"
 
 react-transform-catch-errors@^1.0.2:
   version "1.0.2"
@@ -5805,6 +5876,10 @@ scss-tokenizer@^0.2.3:
 select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
+
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
 
 selfsigned@^1.9.1:
   version "1.10.1"
@@ -6454,6 +6529,10 @@ timers-browserify@^2.0.2:
   resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.4.tgz#96ca53f4b794a5e7c0e1bd7cc88a372298fa01e6"
   dependencies:
     setimmediate "^1.0.4"
+
+tiny-emitter@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
 
 title-case@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
## Overview

Layer boxes replace the huge TileJSON teat area on the side bar. These boxes show layer names and the order of the layers. They provide the ability to click in and learn details of the layer. They also provide the ability to look at the TileJSON for the individual layer. A button is available to delete a specific layer or to edit the layer information. Lastly, a quick add box allows the user to throw in a tile url and hit enter to see it as a layer. (Also, hitting enter works on forms now too!)

Connects #8 

### Demo

Starting screen
<img width="1280" alt="screen shot 2017-10-24 at 8 39 07 am" src="https://user-images.githubusercontent.com/3959096/31943579-213a42ec-b897-11e7-9ccd-90d7d7fe0a5a.png">

Enter tile url into quick add
<img width="1280" alt="screen shot 2017-10-24 at 8 39 19 am" src="https://user-images.githubusercontent.com/3959096/31943610-351aa914-b897-11e7-8c1b-6d4b142c47cd.png">

See layer
<img width="1280" alt="screen shot 2017-10-24 at 8 39 34 am" src="https://user-images.githubusercontent.com/3959096/31943626-43c57c78-b897-11e7-973f-a50a5b42d08a.png">

View layer details
<img width="1280" alt="screen shot 2017-10-24 at 8 39 39 am" src="https://user-images.githubusercontent.com/3959096/31943692-7fef04d0-b897-11e7-84a6-aa7ba37bf1c0.png">

View layer source
<img width="1280" alt="screen shot 2017-10-24 at 8 39 41 am" src="https://user-images.githubusercontent.com/3959096/31943703-877a4d90-b897-11e7-881b-180bd079ff04.png">

Add new layer
<img width="1280" alt="screen shot 2017-10-24 at 8 39 54 am" src="https://user-images.githubusercontent.com/3959096/31943710-901887aa-b897-11e7-9218-4168997219c2.png">

Edit popup for first layer
<img width="1280" alt="screen shot 2017-10-24 at 8 40 11 am" src="https://user-images.githubusercontent.com/3959096/31943713-948f0bec-b897-11e7-945a-6cd901571767.png">

Change name and tile url
<img width="1280" alt="screen shot 2017-10-24 at 8 40 33 am" src="https://user-images.githubusercontent.com/3959096/31943715-995b0ffe-b897-11e7-90e9-05fc4f5a2616.png">

See the change in place 
<img width="1280" alt="screen shot 2017-10-24 at 8 40 53 am" src="https://user-images.githubusercontent.com/3959096/31943720-9f417ee4-b897-11e7-9b1d-197cf38526a4.png">

Delete old layer
<img width="1280" alt="screen shot 2017-10-24 at 8 40 59 am" src="https://user-images.githubusercontent.com/3959096/31943724-a39c52fc-b897-11e7-94af-c91bacb80b7a.png">


## Testing Instructions

 * Pull branch, serve locally
 * Test the Quick Add box by adding some tile url to that. Also add using the add popup. 
 * Test the view details expand/collapse button for each layer.
 * Test the view code button for each layer.
 * Test the delete button for the layers.
 * Test editing a layer and replacing the url with a new one and see the layer change while keeping its place.