### PR TITLE
Add diff view to compare two layers

### DIFF
--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -36,6 +36,7 @@ import {
 import AddLayerDialog from './AddLayerDialog';
 import NavBar from './NavBar';
 import SideBar from './SideBar';
+import DiffToolbar from './DiffToolbar';
 
 class App extends Component {
     constructor(props) {
@@ -238,7 +239,8 @@ class App extends Component {
             backgroundColor: '#fd4582',
         };
         let bar;
-        if (this.props.isCollapsed) {
+        let diffToolbar;
+        if (this.props.isCollapsed || this.props.diffMode) {
             bar = (
                 <NavBar
                     openAddLayerDialog={this.openAddLayerDialog}
@@ -246,6 +248,9 @@ class App extends Component {
                     clearLayers={this.clearLayers}
                 />
             );
+            if (this.props.diffMode) {
+                diffToolbar = (<DiffToolbar />);
+            }
         } else {
             bar = (
                 <SideBar
@@ -256,19 +261,26 @@ class App extends Component {
                     removeLayers={this.removeLayers}
                     removeLayer={this.removeLayer}
                     changeBaseLayer={this.changeBaseLayer}
+                    openDiffMode={this.openDiffMode}
                 />
             );
+        }
+        let mapClassName = 'map mapCollapsed';
+        if (this.props.diffMode) {
+            mapClassName = 'map mapDiff';
+        } else if (this.props.isCollapsed) {
+            mapClassName = 'map mapExpanded';
         }
         return (
             <MuiThemeProvider>
                 <div>
                     <Row>
                         {bar}
+                        {diffToolbar}
                         <Col
-                            xs={this.props.isCollapsed ? 12 : 8}
+                            xs={this.props.isCollapsed || this.props.diffMode ? 12 : 8}
                             id="map"
-                            className={this.props.isCollapsed ?
-                                'map mapExpanded' : 'map mapCollapsed'}
+                            className={mapClassName}
                         />
                         <Snackbar
                             open={this.props.shareSnackbarOpen}
@@ -307,6 +319,7 @@ App.propTypes = {
     errorSnackbarOpen: bool.isRequired,
     isCollapsed: bool.isRequired,
     currentBaseLayer: number.isRequired,
+    diffMode: bool.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/DiffToolbar.jsx
+++ b/src/app/js/src/DiffToolbar.jsx
@@ -1,0 +1,173 @@
+import React, { Component } from 'react';
+import { arrayOf, func, number, object } from 'prop-types';
+import { connect } from 'react-redux';
+
+import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar';
+import DropDownMenu from 'material-ui/DropDownMenu';
+import MenuItem from 'material-ui/MenuItem';
+import Slider from 'material-ui/Slider';
+import { Col } from 'react-flexbox-grid';
+import TileLayer from 'ol/layer/tile';
+import XYZ from 'ol/source/xyz';
+import Map from 'ol/map';
+import View from 'ol/view';
+
+import {
+    map,
+} from './constants';
+import {
+    changeDiffLeftLayerId,
+    changeDiffRightLayerId,
+} from './actions';
+
+class DiffToolbar extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            swipeValue: 0.5,
+        };
+        this.leftLayerChange = this.leftLayerChange.bind(this);
+        this.rightLayerChange = this.rightLayerChange.bind(this);
+        this.changeSwipeValue = this.changeSwipeValue.bind(this);
+    }
+
+    componentDidMount() {
+        const layers = map.getLayers().getArray();
+        this.diffMap = new Map({
+            layers: [
+                layers[0],
+                new TileLayer({
+                    source: new XYZ({
+                        url: this.props.layers[this.props.diffLayerLeftId].url,
+                    }),
+                }),
+                new TileLayer({
+                    source: new XYZ({
+                        url: this.props.layers[this.props.diffLayerRightId].url,
+                    }),
+                }),
+            ],
+            view: new View({
+                center: [0, 0],
+                zoom: 2,
+            }),
+        });
+
+        const diffMapLayers = this.diffMap.getLayers().getArray();
+
+        diffMapLayers[1].on('precompose', (event) => {
+            const ctx = event.context;
+            const width = ctx.canvas.width * this.state.swipeValue;
+
+            ctx.save();
+            ctx.beginPath();
+            ctx.rect(0, 0, width, ctx.canvas.height);
+            ctx.clip();
+        });
+        diffMapLayers[1].on('postcompose', (event) => {
+            const ctx = event.context;
+            ctx.restore();
+        });
+
+        diffMapLayers[2].on('precompose', (event) => {
+            const ctx = event.context;
+            const width = ctx.canvas.width * this.state.swipeValue;
+
+            ctx.save();
+            ctx.beginPath();
+            ctx.rect(width, 0, ctx.canvas.width - width, ctx.canvas.height);
+            ctx.clip();
+        });
+        diffMapLayers[2].on('postcompose', (event) => {
+            const ctx = event.context;
+            ctx.restore();
+        });
+
+        map.setTarget(null);
+        this.diffMap.setTarget('map');
+    }
+
+    componentWillUnmount() {
+        this.diffMap.setTarget(null);
+        map.setTarget('map');
+    }
+
+    leftLayerChange(event, index, value) {
+        const diffMapLayers = this.diffMap.getLayers().getArray();
+        diffMapLayers[1].setSource(new XYZ({
+            url: this.props.layers[value].url,
+        }));
+        this.props.dispatch(changeDiffLeftLayerId({
+            id: value,
+        }));
+    }
+
+    rightLayerChange(event, index, value) {
+        const diffMapLayers = this.diffMap.getLayers().getArray();
+        diffMapLayers[2].setSource(new XYZ({
+            url: this.props.layers[value].url,
+        }));
+        this.props.dispatch(changeDiffRightLayerId({
+            id: value,
+        }));
+    }
+
+    changeSwipeValue(event, value) {
+        this.setState({
+            swipeValue: value,
+        }, this.diffMap.render());
+    }
+
+    render() {
+        const leftDropdown = this.props.layers.map((layer, i) => {
+            if (i === this.props.diffLayerRightId) {
+                return null;
+            }
+            return (<MenuItem key={i} value={i} primaryText={layer.name} />);
+        });
+        const rightDropdown = this.props.layers.map((layer, i) => {
+            if (i === this.props.diffLayerLeftId) {
+                return null;
+            }
+            return (<MenuItem key={i} value={i} primaryText={layer.name} />);
+        });
+        return (
+            <Col xs={12} id="diffToolbar">
+                <Toolbar>
+                    <ToolbarGroup>
+                        <ToolbarTitle text="Left Layer" />
+                        <DropDownMenu
+                            value={this.props.diffLayerLeftId}
+                            onChange={this.leftLayerChange}
+                        >
+                            {leftDropdown}
+                        </DropDownMenu>
+                    </ToolbarGroup>
+                    <ToolbarGroup>
+                        <DropDownMenu
+                            value={this.props.diffLayerRightId}
+                            onChange={this.rightLayerChange}
+                        >
+                            {rightDropdown}
+                        </DropDownMenu>
+                        <ToolbarTitle text="Right Layer" />
+                    </ToolbarGroup>
+                </Toolbar>
+                <Slider value={this.state.swipeValue} onChange={this.changeSwipeValue} />
+            </Col>
+        );
+    }
+}
+
+DiffToolbar.propTypes = {
+    dispatch: func.isRequired,
+    layers: arrayOf(object).isRequired,
+    diffLayerLeftId: number.isRequired,
+    diffLayerRightId: number.isRequired,
+};
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+export default connect(mapStateToProps)(DiffToolbar);

--- a/src/app/js/src/NavBar.jsx
+++ b/src/app/js/src/NavBar.jsx
@@ -1,16 +1,18 @@
 import React, { Component } from 'react';
-import { func } from 'prop-types';
+import { bool, func } from 'prop-types';
 import { connect } from 'react-redux';
 
 import FlatButton from 'material-ui/FlatButton';
 import IconButton from 'material-ui/IconButton';
-import ExpandMore from 'material-ui/svg-icons/navigation/expand-more';
+import NavigationExpandMoreIcon from 'material-ui/svg-icons/navigation/expand-more';
+import NavigationCloseIcon from 'material-ui/svg-icons/navigation/close';
 import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar';
 
 import { Col } from 'react-flexbox-grid';
 
 import {
     toggleCollapse,
+    toggleDiffMode,
 } from './actions';
 import {
     map,
@@ -20,11 +22,21 @@ class NavBar extends Component {
     constructor(props) {
         super(props);
         this.expand = this.expand.bind(this);
+        this.closeDiffMode = this.closeDiffMode.bind(this);
     }
 
     expand() {
         this.props.dispatch(toggleCollapse({
             isCollapsed: false,
+        }));
+        setTimeout(() => {
+            map.updateSize();
+        }, 100);
+    }
+
+    closeDiffMode() {
+        this.props.dispatch(toggleDiffMode({
+            diffMode: false,
         }));
         setTimeout(() => {
             map.updateSize();
@@ -38,18 +50,30 @@ class NavBar extends Component {
         const styleBlueBackground = {
             backgroundColor: '#00bcd6',
         };
+        let toolbarGroupIconButton = (
+            <IconButton onClick={this.expand}><NavigationExpandMoreIcon color="white" /></IconButton>
+        );
+        let toolbarGroupRight = (
+            <ToolbarGroup lastChild>
+                <FlatButton onClick={this.props.openAddLayerDialog} label="Add Layer" style={styleWhiteText} />
+                <FlatButton onClick={this.props.share} label="Share" style={styleWhiteText} />
+                <FlatButton onClick={this.props.clearLayers} label="Clear" style={styleWhiteText} />
+            </ToolbarGroup>
+        );
+        if (this.props.diffMode) {
+            toolbarGroupIconButton = (
+                <IconButton onClick={this.closeDiffMode}><NavigationCloseIcon color="white" /></IconButton>
+            );
+            toolbarGroupRight = null;
+        }
         return (
             <Col xs={12} id="header">
                 <Toolbar style={styleBlueBackground}>
                     <ToolbarGroup firstChild>
-                        <IconButton onClick={this.expand}><ExpandMore color="white" /></IconButton>
+                        {toolbarGroupIconButton}
                         <ToolbarTitle text="TileJSON.io" style={styleWhiteText} />
                     </ToolbarGroup>
-                    <ToolbarGroup lastChild>
-                        <FlatButton onClick={this.props.openAddLayerDialog} label="Add Layer" style={styleWhiteText} />
-                        <FlatButton onClick={this.props.share} label="Share" style={styleWhiteText} />
-                        <FlatButton onClick={this.props.clearLayers} label="Clear" style={styleWhiteText} />
-                    </ToolbarGroup>
+                    {toolbarGroupRight}
                 </Toolbar>
             </Col>
         );
@@ -61,6 +85,7 @@ NavBar.propTypes = {
     openAddLayerDialog: func.isRequired,
     share: func.isRequired,
     clearLayers: func.isRequired,
+    diffMode: bool.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/SideBar.jsx
+++ b/src/app/js/src/SideBar.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { bool, func, string } from 'prop-types';
+import { arrayOf, bool, func, object, string } from 'prop-types';
 import { connect } from 'react-redux';
 
 import TileLayer from 'ol/layer/tile';
@@ -23,6 +23,7 @@ import {
     toggleCollapse,
     toggleErrorSnackbarOpen,
     toggleTileJSONEditMode,
+    toggleDiffMode,
 } from './actions';
 import {
     map,
@@ -35,6 +36,7 @@ class SideBar extends Component {
         this.collapse = this.collapse.bind(this);
         this.editTileJSON = this.editTileJSON.bind(this);
         this.renderTileJSON = this.renderTileJSON.bind(this);
+        this.openDiffMode = this.openDiffMode.bind(this);
     }
 
     collapse() {
@@ -50,6 +52,15 @@ class SideBar extends Component {
         this.props.dispatch(toggleTileJSONEditMode({
             tileJSONEditMode: true,
         }));
+    }
+
+    openDiffMode() {
+        this.props.dispatch(toggleDiffMode({
+            diffMode: true,
+        }));
+        setTimeout(() => {
+            map.updateSize();
+        }, 100);
     }
 
     renderTileJSON() {
@@ -164,13 +175,22 @@ class SideBar extends Component {
                 <Grid fluid>
                     <br />
                     <Row>
-                        <Col xs={4}>
+                        <Col xs={3}>
                             <FlatButton onClick={this.props.openAddLayerDialog} label="Add" primary fullWidth />
                         </Col>
-                        <Col xs={4}>
+                        <Col xs={3}>
+                            <FlatButton
+                                onClick={this.openDiffMode}
+                                label="Diff"
+                                disabled={this.props.layers.length < 2}
+                                primary
+                                fullWidth
+                            />
+                        </Col>
+                        <Col xs={3}>
                             <FlatButton onClick={this.props.share} label="Share" primary fullWidth />
                         </Col>
-                        <Col xs={4}>
+                        <Col xs={3}>
                             <FlatButton onClick={this.props.clearLayers} label="Clear" primary fullWidth />
                         </Col>
                     </Row>
@@ -193,6 +213,7 @@ SideBar.propTypes = {
     tileJSONEditMode: bool.isRequired,
     tileJSONString: string.isRequired,
     changeBaseLayer: func.isRequired,
+    layers: arrayOf(object).isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/actions.js
+++ b/src/app/js/src/actions.js
@@ -24,6 +24,10 @@ export const TOGGLE_BASE_LAYER_DETAILS = 'TOGGLE_BASE_LAYER_DETAILS';
 
 export const CHANGE_CURRENT_BASE_LAYER = 'CHANGE_CURRENT_BASE_LAYER';
 
+export const TOGGLE_DIFF_MODE = 'TOGGLE_DIFF_MODE';
+export const CHANGE_DIFF_LEFT_LAYER_ID = 'CHANGE_DIFF_LEFT_LAYER_ID';
+export const CHANGE_DIFF_RIGHT_LAYER_ID = 'CHANGE_DIFF_RIGHT_LAYER_ID';
+
 export function changeLayerName(payload) {
     return {
         type: CHANGE_LAYER_NAME,
@@ -153,6 +157,27 @@ export function toggleBaseLayerDetails(payload) {
 export function changeCurrentBaseLayer(payload) {
     return {
         type: CHANGE_CURRENT_BASE_LAYER,
+        payload,
+    };
+}
+
+export function toggleDiffMode(payload) {
+    return {
+        type: TOGGLE_DIFF_MODE,
+        payload,
+    };
+}
+
+export function changeDiffLeftLayerId(payload) {
+    return {
+        type: CHANGE_DIFF_LEFT_LAYER_ID,
+        payload,
+    };
+}
+
+export function changeDiffRightLayerId(payload) {
+    return {
+        type: CHANGE_DIFF_RIGHT_LAYER_ID,
         payload,
     };
 }

--- a/src/app/js/src/reducers.js
+++ b/src/app/js/src/reducers.js
@@ -20,6 +20,9 @@ import {
     POST_ADD_EDIT_CLEAR,
     TOGGLE_BASE_LAYER_DETAILS,
     CHANGE_CURRENT_BASE_LAYER,
+    TOGGLE_DIFF_MODE,
+    CHANGE_DIFF_LEFT_LAYER_ID,
+    CHANGE_DIFF_RIGHT_LAYER_ID,
 } from './actions';
 
 import {
@@ -44,6 +47,10 @@ const initialState = {
     editLayerId: -1,
     currentBaseLayer: defaultBaseLayer,
     baseLayerDetails: false,
+    diffMode: false,
+    diffLayerLeftId: -1,
+    diffLayerRightId: -1,
+    swipeValue: 0.5,
 };
 
 function mainReducer(state = initialState, action) {
@@ -77,6 +84,10 @@ function mainReducer(state = initialState, action) {
                 showEditLayerDialog: false,
                 editLayerId: -1,
                 baseLayerDetails: false,
+                diffMode: false,
+                diffLayerLeftId: -1,
+                diffLayerRightId: -1,
+                swipeValue: 0.5,
             });
         case CHANGE_SHARE_LINK:
             return Object.assign({}, state, {
@@ -185,6 +196,31 @@ function mainReducer(state = initialState, action) {
         case CHANGE_CURRENT_BASE_LAYER:
             return Object.assign({}, state, {
                 currentBaseLayer: action.payload.currentBaseLayer,
+            });
+        case TOGGLE_DIFF_MODE: {
+            if (action.payload.diffMode) {
+                if (state.layers.length < 2) {
+                    return state;
+                }
+                return Object.assign({}, state, {
+                    diffMode: true,
+                    diffLayerLeftId: 0,
+                    diffLayerRightId: 1,
+                });
+            }
+            return Object.assign({}, state, {
+                diffMode: false,
+                diffLayerLeftId: -1,
+                diffLayerRightId: -1,
+            });
+        }
+        case CHANGE_DIFF_LEFT_LAYER_ID:
+            return Object.assign({}, state, {
+                diffLayerLeftId: action.payload.id,
+            });
+        case CHANGE_DIFF_RIGHT_LAYER_ID:
+            return Object.assign({}, state, {
+                diffLayerRightId: action.payload.id,
             });
         default:
             return state;

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -23,7 +23,7 @@
     "axios": "0.16.2",
     "isomorphic-fetch": "2.2.1",
     "leaflet": "1.2.0",
-    "material-ui": "0.19.2",
+    "material-ui": "0.19.4",
     "ol": "4.3.3",
     "prop-types": "15.5.10",
     "react": "15.6.1",

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -34,6 +34,10 @@ html, body, #root, [data-reactroot], [data-reactroot] > div {
     max-height: calc(100% - 56px);
 }
 
+.mapDiff {
+    max-height: calc(100% - 112px - 56px);
+}
+
 #jsonTextarea {
     width: 100%;
     height: 400px;
@@ -45,4 +49,8 @@ html, body, #root, [data-reactroot], [data-reactroot] > div {
 
 .detailValue {
     word-break: break-all;
+}
+
+#diffToolbar {
+    height: 112px;
 }

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -811,7 +811,7 @@ babel-register@^6.14.0, babel-register@^6.26.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.15"
 
-babel-runtime@^6.18.0, babel-runtime@^6.20.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.1:
+babel-runtime@^6.18.0, babel-runtime@^6.22.0, babel-runtime@^6.23.0, babel-runtime@^6.26.0, babel-runtime@^6.9.1:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-runtime/-/babel-runtime-6.26.0.tgz#965c7058668e82b55d7bfe04ff2337bc8b5647fe"
   dependencies:
@@ -2545,9 +2545,21 @@ fbemitter@^2.0.0:
   dependencies:
     fbjs "^0.8.4"
 
-fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.9:
+fbjs@^0.8.0, fbjs@^0.8.4, fbjs@^0.8.9:
   version "0.8.15"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.15.tgz#4f0695fdfcc16c37c0b07facec8cb4c4091685b9"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+fbjs@^0.8.1, fbjs@^0.8.16:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -3022,9 +3034,13 @@ hoek@2.x.x:
   version "2.16.3"
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-2.16.3.tgz#20bb7403d3cea398e91dc4710a8ff1b8274a25ed"
 
-hoist-non-react-statics@^1.0.0, hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.2.0:
+hoist-non-react-statics@^1.0.3, hoist-non-react-statics@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz#aa448cf0986d55cc40773b17174b7dd066cb7cfb"
+
+hoist-non-react-statics@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.3.1.tgz#343db84c6018c650778898240135a1420ee22ce0"
 
 home-or-tmp@^2.0.0:
   version "2.0.0"
@@ -4024,9 +4040,9 @@ marked@^0.3.6:
   version "0.3.6"
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.6.tgz#b2c6c618fccece4ef86c4fc6cb8a7cbf5aeda8d7"
 
-material-ui@0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.19.2.tgz#98c8898c933279b12df879d7184306aceb364cb5"
+material-ui@0.19.4:
+  version "0.19.4"
+  resolved "https://registry.yarnpkg.com/material-ui/-/material-ui-0.19.4.tgz#ca9cdca8aa8bb594dfac5db38ec9ff045a323587"
   dependencies:
     babel-runtime "^6.23.0"
     inline-style-prefixer "^3.0.2"
@@ -4034,9 +4050,9 @@ material-ui@0.19.2:
     lodash.merge "^4.6.0"
     lodash.throttle "^4.1.1"
     prop-types "^15.5.7"
-    react-event-listener "^0.4.5"
-    react-transition-group "^1.1.2"
-    recompose "0.24.0"
+    react-event-listener "^0.5.1"
+    react-transition-group "^1.2.1"
+    recompose "^0.26.0"
     simple-assign "^0.1.0"
     warning "^3.0.0"
 
@@ -5182,6 +5198,14 @@ prop-types@15.5.10, prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4,
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
+prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 protocol-buffers-schema@^2.0.2:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/protocol-buffers-schema/-/protocol-buffers-schema-2.2.0.tgz#d29c6cd73fb655978fb6989691180db844119f61"
@@ -5316,13 +5340,13 @@ react-dom@15.6.1:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react-event-listener@^0.4.5:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.4.5.tgz#e3e895a0970cf14ee8f890113af68197abf3d0b1"
+react-event-listener@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/react-event-listener/-/react-event-listener-0.5.1.tgz#ba36076e47bc37c5a67ff5ccd4a9ff0f15621040"
   dependencies:
-    babel-runtime "^6.20.0"
-    fbjs "^0.8.4"
-    prop-types "^15.5.4"
+    babel-runtime "^6.26.0"
+    fbjs "^0.8.16"
+    prop-types "^15.6.0"
     warning "^3.0.0"
 
 react-flexbox-grid@1.1.5:
@@ -5416,9 +5440,9 @@ react-transform-hmr@^1.0.3:
     global "^4.3.0"
     react-proxy "^1.1.7"
 
-react-transition-group@^1.1.2:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.0.tgz#b51fc921b0c3835a7ef7c571c79fc82c73e9204f"
+react-transition-group@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-1.2.1.tgz#e11f72b257f921b213229a774df46612346c7ca6"
   dependencies:
     chain-function "^1.0.0"
     dom-helpers "^3.2.0"
@@ -5530,13 +5554,13 @@ rechoir@^0.6.2:
   dependencies:
     resolve "^1.1.6"
 
-recompose@0.24.0:
-  version "0.24.0"
-  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.24.0.tgz#262e93f974439eb17e7779824d88cce90492a5dd"
+recompose@^0.26.0:
+  version "0.26.0"
+  resolved "https://registry.yarnpkg.com/recompose/-/recompose-0.26.0.tgz#9babff039cb72ba5bd17366d55d7232fbdfb2d30"
   dependencies:
     change-emitter "^0.1.2"
     fbjs "^0.8.1"
-    hoist-non-react-statics "^1.0.0"
+    hoist-non-react-statics "^2.3.1"
     symbol-observable "^1.0.4"
 
 redbox-react@^1.2.2:


### PR DESCRIPTION
## Overview

This PR allows you to enter diff mode when 2 or more layers are entered on the map. The diff mode allows a split-screen view of 2 layers with a slider above the map to control the border. There is also a drop-down menu where other layers can be picked for comparing. 

Connects #30 

### Demo

![screen shot 2017-11-09 at 9 43 51 am 2](https://user-images.githubusercontent.com/3959096/32611205-012110d2-c533-11e7-8f63-e5685a525fba.png)

![screen shot 2017-11-09 at 9 44 21 am 2](https://user-images.githubusercontent.com/3959096/32611209-0404a700-c533-11e7-9613-36a67cdb0fc6.png)

![screen shot 2017-11-09 at 9 44 25 am 2](https://user-images.githubusercontent.com/3959096/32611216-07a3b98c-c533-11e7-8893-53b2fd6f6082.png)

![screen shot 2017-11-09 at 9 44 32 am 2](https://user-images.githubusercontent.com/3959096/32611223-0a70c1a0-c533-11e7-936b-c8fcef89a35d.png)


### Notes

The slider value is a local react state because the render of the map needs to happen as soon as that is changed. It is also only ever used in the `DiffToolbar` component. 

## Testing Instructions

 * Pull and run
 * Add 3 or more layers
 * Enter diff mode
 * Play with slider
 * Change layers
 * Exit diff mode to see if the map changes back to the old view
 * Re-enter diff mode 
