### PR TITLE
Move slider control for diff mode over the map

### DIFF
--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -32,6 +32,7 @@ import {
     getDefaultTileJSON,
     getBaseLayerTileJSON,
     baseLayers,
+    muiTheme,
 } from './constants';
 import AddLayerDialog from './AddLayerDialog';
 import NavBar from './NavBar';
@@ -272,7 +273,7 @@ class App extends Component {
             mapClassName = 'map mapExpanded';
         }
         return (
-            <MuiThemeProvider>
+            <MuiThemeProvider muiTheme={muiTheme}>
                 <div>
                     <Row>
                         {bar}

--- a/src/app/js/src/DiffToolbar.jsx
+++ b/src/app/js/src/DiffToolbar.jsx
@@ -80,16 +80,22 @@ class DiffToolbar extends Component {
         });
         diffMapLayers[2].on('postcompose', (event) => {
             const ctx = event.context;
+            const width = ctx.canvas.width * this.state.swipeValue;
+
+            ctx.restore();
+
+            ctx.save();
+            ctx.fillStyle = '#ffffff';
+            ctx.beginPath();
+            ctx.fillRect(width - 6, 0, 12, ctx.canvas.height);
             ctx.restore();
         });
 
-        map.setTarget(null);
-        this.diffMap.setTarget('map');
+        this.diffMap.setTarget('diffMap');
     }
 
     componentWillUnmount() {
         this.diffMap.setTarget(null);
-        map.setTarget('map');
     }
 
     leftLayerChange(event, index, value) {
@@ -153,7 +159,10 @@ class DiffToolbar extends Component {
                         <ToolbarTitle text="Right Layer" />
                     </ToolbarGroup>
                 </Toolbar>
-                <Slider value={this.state.swipeValue} onChange={this.changeSwipeValue} />
+                <div id="diffMap" className="diffMap" />
+                <div id="overDiffMap" className="overDiffMap">
+                    <Slider className="slider" value={this.state.swipeValue} onChange={this.changeSwipeValue} sliderStyle={{ marginBottom: 0, marginTop: 0 }} />
+                </div>
             </Col>
         );
     }

--- a/src/app/js/src/constants.js
+++ b/src/app/js/src/constants.js
@@ -3,6 +3,7 @@ import XYZ from 'ol/source/xyz';
 import Attribution from 'ol/attribution';
 import Map from 'ol/map';
 import View from 'ol/view';
+import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
 export const baseLayers = [
     {
@@ -57,3 +58,12 @@ export function getBaseLayerTileJSON(i) {
         ],
     };
 }
+
+export const muiTheme = getMuiTheme({
+    slider: {
+        handleSize: 36,
+        handleSizeDisabled: 32,
+        handleSizeActive: 48,
+        trackSize: 0,
+    },
+});

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -1,6 +1,6 @@
 @import "../node_modules/ol/ol.css";
 
-html, body, #root, [data-reactroot], [data-reactroot] > div { 
+html, body, #root, #root > div , #root > div > div { 
     margin:0; 
     padding:0; 
     height:100%;

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -35,7 +35,7 @@ html, body, #root, [data-reactroot], [data-reactroot] > div {
 }
 
 .mapDiff {
-    max-height: calc(100% - 112px - 56px);
+    max-height: calc(100% - 112px);
 }
 
 #jsonTextarea {
@@ -53,4 +53,22 @@ html, body, #root, [data-reactroot], [data-reactroot] > div {
 
 #diffToolbar {
     height: 112px;
+}
+
+#diffMap {
+    position: absolute;
+    top: 112px;
+    left: 0px;
+    width: 100%;
+    max-height: calc(100% - 112px);
+    z-index: 500;
+}
+
+#overDiffMap {
+    position: absolute;
+    top: 136px;
+    left: 0px;
+    width: 100%;
+    max-height: calc(100% - 112px);
+    z-index: 1000;
 }


### PR DESCRIPTION
## Overview

Slider is over the map for maximum user-friendliness! 

Connects #47 

### Demo

![screen shot 2017-11-10 at 11 51 45 am 2](https://user-images.githubusercontent.com/3959096/32670920-5d903cf4-c613-11e7-8402-835f73a65114.png)

### Notes

Above the slider, map controls like zoom don't work. This doesn't seem like it would cause a lot of pain to the user, but maybe we should add an issue to investigate? 

## Testing Instructions

 * pull, run
 * add 2 layers and enter diff mode
