### PR TITLE
Replace share snackbar with a share dialog

### DIFF
--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -34,6 +34,7 @@ import {
     baseLayers,
 } from './constants';
 import AddLayerDialog from './AddLayerDialog';
+import ShareDialog from './ShareDialog';
 import NavBar from './NavBar';
 import SideBar from './SideBar';
 import DiffToolbar from './DiffToolbar';
@@ -47,7 +48,6 @@ class App extends Component {
         this.layersCounter = 1;
         this.clearLayers = this.clearLayers.bind(this);
         this.share = this.share.bind(this);
-        this.handleShareSbRequestClose = this.handleShareSbRequestClose.bind(this);
         this.handleErrorSbRequestClose = this.handleErrorSbRequestClose.bind(this);
         this.openAddLayerDialog = this.openAddLayerDialog.bind(this);
         this.addLayer = this.addLayer.bind(this);
@@ -213,12 +213,6 @@ class App extends Component {
             });
     }
 
-    handleShareSbRequestClose() {
-        this.props.dispatch(toggleShareSnackbarOpen({
-            shareSnackbarOpen: false,
-        }));
-    }
-
     handleErrorSbRequestClose() {
         this.props.dispatch(toggleErrorSnackbarOpen({
             errorSnackbarOpen: false,
@@ -232,9 +226,6 @@ class App extends Component {
     }
 
     render() {
-        const shareSnackbarMessage = (
-            <a className="snackbarLink" href={this.props.shareLink}>{this.props.shareLink}</a>
-        );
         const errorSnackbarStyle = {
             backgroundColor: '#fd4582',
         };
@@ -283,11 +274,6 @@ class App extends Component {
                             className={mapClassName}
                         />
                         <Snackbar
-                            open={this.props.shareSnackbarOpen}
-                            message={shareSnackbarMessage}
-                            onRequestClose={this.handleShareSbRequestClose}
-                        />
-                        <Snackbar
                             open={this.props.errorSnackbarOpen}
                             message={this.props.tileJSONParseError}
                             onRequestClose={this.handleErrorSbRequestClose}
@@ -301,6 +287,7 @@ class App extends Component {
                             editMode
                             editLayer={this.editLayer}
                         />
+                        <ShareDialog />
                     </Row>
                 </div>
             </MuiThemeProvider>
@@ -313,9 +300,7 @@ App.propTypes = {
     name: string.isRequired,
     url: string.isRequired,
     tileJSON: arrayOf(object).isRequired,
-    shareLink: string.isRequired,
     tileJSONParseError: string.isRequired,
-    shareSnackbarOpen: bool.isRequired,
     errorSnackbarOpen: bool.isRequired,
     isCollapsed: bool.isRequired,
     currentBaseLayer: number.isRequired,

--- a/src/app/js/src/ShareDialog.jsx
+++ b/src/app/js/src/ShareDialog.jsx
@@ -1,0 +1,81 @@
+import React, { Component } from 'react';
+import { bool, func, string } from 'prop-types';
+import { connect } from 'react-redux';
+
+import Dialog from 'material-ui/Dialog';
+import FlatButton from 'material-ui/FlatButton';
+import TextField from 'material-ui/TextField';
+
+import { CopyToClipboard } from 'react-copy-to-clipboard';
+
+import {
+    toggleShareSnackbarOpen,
+    toggleShareUrlCopied,
+} from './actions';
+
+class ShareDialog extends Component {
+    constructor(props) {
+        super(props);
+        this.closeShareDialog = this.closeShareDialog.bind(this);
+        this.onCopy = this.onCopy.bind(this);
+    }
+
+    onCopy() {
+        this.props.dispatch(toggleShareUrlCopied({
+            shareUrlCopied: true,
+        }));
+    }
+
+    closeShareDialog() {
+        this.props.dispatch(toggleShareSnackbarOpen({
+            shareSnackbarOpen: false,
+        }));
+    }
+
+    render() {
+        const actions = [
+            <FlatButton
+                label="Close"
+                onClick={this.closeShareDialog}
+            />,
+            <CopyToClipboard
+                text={this.props.shareLink}
+                onCopy={this.onCopy}
+            >
+                <FlatButton
+                    label="Copy URL"
+                    primary
+                />
+            </CopyToClipboard>,
+        ];
+        return (
+            <div>
+                <Dialog
+                    title="Share URL"
+                    actions={actions}
+                    modal={false}
+                    open={this.props.shareSnackbarOpen}
+                    onRequestClose={this.closeShareDialog}
+                >
+                    <TextField
+                        name="shareUrl"
+                        value={this.props.shareLink}
+                        fullWidth
+                    />
+                </Dialog>
+            </div>
+        );
+    }
+}
+
+ShareDialog.propTypes = {
+    dispatch: func.isRequired,
+    shareSnackbarOpen: bool.isRequired,
+    shareLink: string.isRequired,
+};
+
+function mapStateToProps(state) {
+    return state.main;
+}
+
+export default connect(mapStateToProps)(ShareDialog);

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -27,6 +27,7 @@
     "ol": "4.3.3",
     "prop-types": "15.5.10",
     "react": "15.6.1",
+    "react-copy-to-clipboard": "5.0.1",
     "react-dom": "15.6.1",
     "react-flexbox-grid": "1.1.5",
     "react-json-view": "1.13.1",

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -1563,6 +1563,12 @@ cookie@0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
 
+copy-to-clipboard@^3:
+  version "3.0.8"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.0.8.tgz#f4e82f4a8830dce4666b7eb8ded0c9bcc313aba9"
+  dependencies:
+    toggle-selection "^1.0.3"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -2545,9 +2551,9 @@ fbemitter@^2.0.0:
   dependencies:
     fbjs "^0.8.4"
 
-fbjs@^0.8.0, fbjs@^0.8.4, fbjs@^0.8.9:
-  version "0.8.15"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.15.tgz#4f0695fdfcc16c37c0b07facec8cb4c4091685b9"
+fbjs@^0.8.0, fbjs@^0.8.1, fbjs@^0.8.16, fbjs@^0.8.4:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -2557,9 +2563,9 @@ fbjs@^0.8.0, fbjs@^0.8.4, fbjs@^0.8.9:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.1, fbjs@^0.8.16:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+fbjs@^0.8.9:
+  version "0.8.15"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.15.tgz#4f0695fdfcc16c37c0b07facec8cb4c4091685b9"
   dependencies:
     core-js "^1.0.0"
     isomorphic-fetch "^2.1.1"
@@ -5191,14 +5197,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@15.5.10, prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8:
+prop-types@15.5.10, prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
 
-prop-types@^15.6.0:
+prop-types@^15.5.4, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
   dependencies:
@@ -5326,6 +5332,13 @@ react-base16-styling@^0.5.3:
     lodash.curry "^4.0.1"
     lodash.flow "^3.3.0"
     pure-color "^1.2.0"
+
+react-copy-to-clipboard@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/react-copy-to-clipboard/-/react-copy-to-clipboard-5.0.1.tgz#8eae107bb400be73132ed3b6a7b4fb156090208e"
+  dependencies:
+    copy-to-clipboard "^3"
+    prop-types "^15.5.8"
 
 react-deep-force-update@^1.0.0:
   version "1.1.1"
@@ -6587,6 +6600,10 @@ to-fast-properties@^1.0.3:
 to-iso-string@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/to-iso-string/-/to-iso-string-0.0.2.tgz#4dc19e664dfccbe25bd8db508b00c6da158255d1"
+
+toggle-selection@^1.0.3:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
 
 toposort@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
## Overview

Making sharing an easy process helps users who primarily want to share tiles. 

Connects #32 

### Demo

![screen shot 2017-11-10 at 4 30 41 pm 2](https://user-images.githubusercontent.com/3959096/32679519-b1fece4c-c634-11e7-9f81-bae76707d2e9.png)

## Testing Instructions

 * Pull and run
 * Add layers and share to see the dialog
 * Hit copy url and check if the url was correctly copied to clipboard
