### PR TITLE
Make UI changes for the sidebar to be more usable

### DIFF
--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -289,10 +289,7 @@ class App extends Component {
         let diffToolbar;
         if (this.props.isCollapsed || this.props.diffMode) {
             bar = (
-                <NavBar
-                    openAddLayerDialog={this.openAddLayerDialog}
-                    clearLayers={this.clearLayers}
-                />
+                <NavBar />
             );
             if (this.props.diffMode) {
                 diffToolbar = (<DiffToolbar />);

--- a/src/app/js/src/LayerBoxes.jsx
+++ b/src/app/js/src/LayerBoxes.jsx
@@ -3,7 +3,6 @@ import { arrayOf, func, object } from 'prop-types';
 import { connect } from 'react-redux';
 
 import LayerBox from './LayerBox';
-import QuickAddLayerBox from './QuickAddLayerBox';
 import BaseLayerBox from './BaseLayerBox';
 
 class LayerBoxes extends Component {
@@ -29,10 +28,6 @@ class LayerBoxes extends Component {
         );
         return (
             <div>
-                <QuickAddLayerBox
-                    addLayer={this.props.addLayer}
-                />
-                <br />
                 <BaseLayerBox
                     changeBaseLayer={this.props.changeBaseLayer}
                 />
@@ -44,7 +39,6 @@ class LayerBoxes extends Component {
 }
 
 LayerBoxes.propTypes = {
-    addLayer: func.isRequired,
     removeLayer: func.isRequired,
     layers: arrayOf(object).isRequired,
     changeBaseLayer: func.isRequired,

--- a/src/app/js/src/NavBar.jsx
+++ b/src/app/js/src/NavBar.jsx
@@ -24,7 +24,6 @@ class NavBar extends Component {
         super(props);
         this.expand = this.expand.bind(this);
         this.closeDiffMode = this.closeDiffMode.bind(this);
-        this.share = this.share.bind(this);
         this.shareDiff = this.shareDiff.bind(this);
     }
 
@@ -46,12 +45,6 @@ class NavBar extends Component {
         }, 100);
     }
 
-    share() {
-        this.props.dispatch(toggleShareDescriptionDialogOpen({
-            shareDescriptionDialogOpen: true,
-        }));
-    }
-
     shareDiff() {
         this.props.dispatch(toggleShareDescriptionDialogOpen({
             shareDescriptionDialogOpen: true,
@@ -68,13 +61,7 @@ class NavBar extends Component {
         let toolbarGroupIconButton = (
             <IconButton onClick={this.expand}><NavigationExpandMoreIcon color="white" /></IconButton>
         );
-        let toolbarGroupRight = (
-            <ToolbarGroup lastChild>
-                <FlatButton onClick={this.props.openAddLayerDialog} label="Add Layer" style={styleWhiteText} />
-                <FlatButton onClick={this.share} label="Share" style={styleWhiteText} />
-                <FlatButton onClick={this.props.clearLayers} label="Clear" style={styleWhiteText} />
-            </ToolbarGroup>
-        );
+        let toolbarGroupRight = null;
         if (this.props.diffMode) {
             toolbarGroupIconButton = (
                 <IconButton onClick={this.closeDiffMode}><NavigationCloseIcon color="white" /></IconButton>
@@ -101,8 +88,6 @@ class NavBar extends Component {
 
 NavBar.propTypes = {
     dispatch: func.isRequired,
-    openAddLayerDialog: func.isRequired,
-    clearLayers: func.isRequired,
     diffMode: bool.isRequired,
 };
 

--- a/src/app/js/src/QuickAddLayerBox.jsx
+++ b/src/app/js/src/QuickAddLayerBox.jsx
@@ -67,8 +67,7 @@ class QuickAddLayerBox extends Component {
                         <Col xsOffset={4} xs={4}>
                             <FlatButton
                                 label="Add"
-                                onChange={this.changeUrl}
-                                value={this.props.url}
+                                onClick={this.props.addLayer}
                                 primary
                                 fullWidth
                             />

--- a/src/app/js/src/QuickAddLayerBox.jsx
+++ b/src/app/js/src/QuickAddLayerBox.jsx
@@ -1,12 +1,12 @@
 import React, { Component } from 'react';
-import { func, string } from 'prop-types';
+import { arrayOf, func, object, string } from 'prop-types';
 import { connect } from 'react-redux';
 
-import IconButton from 'material-ui/IconButton';
-import ContentAddIcon from 'material-ui/svg-icons/content/add';
-import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar';
-import Paper from 'material-ui/Paper';
+import FlatButton from 'material-ui/FlatButton';
 import TextField from 'material-ui/TextField';
+import { Card, CardTitle, CardText } from 'material-ui/Card';
+
+import { Row, Col } from 'react-flexbox-grid';
 
 import {
     changeLayerUrl,
@@ -17,6 +17,10 @@ class QuickAddLayerBox extends Component {
         super(props);
         this.changeUrl = this.changeUrl.bind(this);
         this.quickAddOnKeyDown = this.quickAddOnKeyDown.bind(this);
+    }
+
+    componentDidMount() {
+        this.nameInput.focus();
     }
 
     changeUrl(e) {
@@ -32,42 +36,64 @@ class QuickAddLayerBox extends Component {
     }
 
     render() {
-        const smallIcon = {
-            width: 18,
-            height: 18,
-            color: '#8b8b8b',
-        };
-        const fontSize11 = {
-            fontSize: '11pt',
-        };
+        let paperZDepth = 1;
+        let cardTitle = null;
+        let cardText = null;
+        if (this.props.layers.length === 0) {
+            paperZDepth = 3;
+            cardTitle = <CardTitle title="Welcome to TileJSON.io" />;
+            cardText = (
+                <div>
+                    Add your first layer to the map by entering a Tile URL below.
+                    <br /><br />
+                </div>
+            );
+        }
         return (
-            <Paper zDepth={1} style={{ overflow: 'hidden' }}>
-                <Toolbar>
-                    <ToolbarGroup>
-                        <ToolbarTitle style={fontSize11} text="Quick Add" />
-                        <TextField
-                            style={fontSize11}
-                            hintText="Tile URL"
-                            onChange={this.changeUrl}
-                            value={this.props.url}
-                            onKeyDown={this.quickAddOnKeyDown}
-                        />
-                    </ToolbarGroup>
-                    <ToolbarGroup>
-                        <IconButton iconStyle={smallIcon} onClick={this.props.addLayer} touch>
-                            <ContentAddIcon />
-                        </IconButton>
-                    </ToolbarGroup>
-                </Toolbar>
-            </Paper>
+            <Card zDepth={paperZDepth}>
+                {cardTitle}
+                <CardText>
+                    {cardText}
+                    <TextField
+                        hintText="Tile URL"
+                        value={this.props.url}
+                        onChange={this.changeUrl}
+                        onKeyDown={this.quickAddOnKeyDown}
+                        ref={(input) => { this.nameInput = input; }}
+                        fullWidth
+                    />
+                    <br />
+                    <Row>
+                        <Col xsOffset={4} xs={4}>
+                            <FlatButton
+                                label="Add"
+                                onChange={this.changeUrl}
+                                value={this.props.url}
+                                primary
+                                fullWidth
+                            />
+                        </Col>
+                        <Col xs={4}>
+                            <FlatButton
+                                onClick={this.props.openAddLayerDialog}
+                                label="More"
+                                primary
+                                fullWidth
+                            />
+                        </Col>
+                    </Row>
+                </CardText>
+            </Card>
         );
     }
 }
 
 QuickAddLayerBox.propTypes = {
     dispatch: func.isRequired,
+    openAddLayerDialog: func.isRequired,
     addLayer: func.isRequired,
     url: string.isRequired,
+    layers: arrayOf(object).isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/SideBar.jsx
+++ b/src/app/js/src/SideBar.jsx
@@ -16,6 +16,7 @@ import { Grid, Row, Col } from 'react-flexbox-grid';
 import { validate } from 'tilejson-validator';
 
 import LayerBoxes from './LayerBoxes';
+import QuickAddLayerBox from './QuickAddLayerBox';
 
 import {
     changeTileJson,
@@ -183,10 +184,7 @@ class SideBar extends Component {
                 <Grid fluid>
                     <br />
                     <Row>
-                        <Col xs={3}>
-                            <FlatButton onClick={this.props.openAddLayerDialog} label="Add" primary fullWidth />
-                        </Col>
-                        <Col xs={3}>
+                        <Col xs={4}>
                             <FlatButton
                                 onClick={this.openDiffMode}
                                 label="Diff"
@@ -195,14 +193,30 @@ class SideBar extends Component {
                                 fullWidth
                             />
                         </Col>
-                        <Col xs={3}>
-                            <FlatButton onClick={this.share} label="Share" primary fullWidth />
+                        <Col xs={4}>
+                            <FlatButton
+                                onClick={this.share}
+                                label="Share"
+                                disabled={this.props.layers.length === 0}
+                                primary
+                                fullWidth
+                            />
                         </Col>
-                        <Col xs={3}>
-                            <FlatButton onClick={this.props.clearLayers} label="Clear" primary fullWidth />
+                        <Col xs={4}>
+                            <FlatButton
+                                onClick={this.props.clearLayers}
+                                label="Clear"
+                                disabled={this.props.layers.length === 0}
+                                primary
+                                fullWidth
+                            />
                         </Col>
                     </Row>
                     <br />
+                    <QuickAddLayerBox
+                        addLayer={this.props.addLayer}
+                        openAddLayerDialog={this.props.openAddLayerDialog}
+                    />
                     {sideBarItems}
                 </Grid>
             </Col>


### PR DESCRIPTION
## Overview

This PR enhances the sidebar UI taking Jeff's suggestions into account.
* The Add button that opens the popup is removed and the quick add panel is highlighted. 
* There is an empty state message and extra highlighting that goes away after one layer is added. 
* The focus on load is taken straight to the text box for the tile url. 
* Share and Clear are disabled when there are no layers. 
* In fullscreen (view mode), there are no controls, only a way to get back to the sidebar (edit mode).
* For detailed adds, a More button is provided which opens the popup from before.

Connects #54 

### Demo

<img width="1280" alt="screen shot 2017-11-17 at 7 24 33 am" src="https://user-images.githubusercontent.com/3959096/32947198-aa491d54-cb68-11e7-805f-223c3b9e0a69.png">

<img width="1280" alt="screen shot 2017-11-17 at 7 24 49 am" src="https://user-images.githubusercontent.com/3959096/32947199-ac9ea1fa-cb68-11e7-8883-9ae827ae2dcb.png">

## Testing Instructions

 * Check that the welcome (empty-state) message and focus on the text input on load. Check the emphasis on the add panel on the sidebar. 
 * Check that the buttons above the panel are disabled.
 * Add a layer. 
 * Check that the empty state message disappears, the Share and Clear buttons are enabled, and that the panel shadow decreases.
 * Click More and add a new layer through the popup. 
 * Collapse the sidebar and check to see that no buttons appear on the navbar.