### PR TITLE
Small site design improvements

### DIFF
--- a/src/app/js/src/NavBar.jsx
+++ b/src/app/js/src/NavBar.jsx
@@ -73,7 +73,7 @@ class NavBar extends Component {
             );
         }
         return (
-            <Col xs={12} id="header">
+            <Col xs={12} id={this.props.diffMode ? 'header' : 'floatingheader'}>
                 <Toolbar style={styleBlueBackground}>
                     <ToolbarGroup firstChild>
                         {toolbarGroupIconButton}

--- a/src/app/js/src/constants.js
+++ b/src/app/js/src/constants.js
@@ -62,8 +62,15 @@ export function getBaseLayerTileJSON(i) {
 export const muiTheme = getMuiTheme({
     slider: {
         handleSize: 36,
-        handleSizeDisabled: 32,
-        handleSizeActive: 48,
+        handleSizeDisabled: 36,
+        handleSizeActive: 36,
         trackSize: 0,
+        rippleColor: 'none',
+        handleColorZero: '#7d7d7d',
+        handleFillColor: '#7d7d7d',
+        selectionColor: '#7d7d7d',
+    },
+    dropDownMenu: {
+        accentColor: '#000',
     },
 });

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -22,6 +22,20 @@ html, body, #root, #root > div , #root > div > div {
     z-index: 100;
 }
 
+#floatingheader {
+    padding: 0 !important;
+    z-index: 100;
+    position: absolute;
+    top: 0;
+    left: 0;
+}
+
+.ol-zoom {
+    top: .5em;
+    right: .5em;
+    left: auto;
+}
+
 #map {
     padding: 0 !important;
 }
@@ -31,7 +45,7 @@ html, body, #root, #root > div , #root > div > div {
 }
 
 .mapExpanded {
-    max-height: calc(100% - 56px);
+    max-height: 100%;
 }
 
 .mapDiff {


### PR DESCRIPTION
## Overview

Reduce size of nav in fullscreen mode
Improve design of diff screen dropdowns
Improve look of diff screen slider

Connects #66 

## Testing Instructions

 * Check to see if in full screen mode, the nav bar is smaller and less obtrusive to viewing
 * Check to see if zoom controls can be seen on the right
 * In diff mode, check to see that the dropdowns look like dropdowns with the inverted carats
 * Check to see that diff screen slider doesn't do animations anymore, a first step to moving towards making it more like the leaflet slider