### PR TITLE
Fix diff mode bug on opening and closing browser dev console

### DIFF
--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -296,12 +296,6 @@ class App extends Component {
                 />
             );
         }
-        let mapClassName = 'map mapCollapsed';
-        if (this.props.diffMode) {
-            mapClassName = 'map mapDiff';
-        } else if (this.props.isCollapsed) {
-            mapClassName = 'map mapExpanded';
-        }
         return (
             <MuiThemeProvider>
                 <div>
@@ -311,7 +305,7 @@ class App extends Component {
                         <Col
                             xs={this.props.isCollapsed || this.props.diffMode ? 12 : 8}
                             id="map"
-                            className={mapClassName}
+                            className="map"
                         />
                         <Snackbar
                             open={this.props.errorSnackbarOpen}

--- a/src/app/sass/main.scss
+++ b/src/app/sass/main.scss
@@ -66,7 +66,7 @@ html, body, #root, #root > div , #root > div > div {
 }
 
 #diffToolbar {
-    height: 112px;
+    height: calc(100% - 56px);
 }
 
 #diffMap {
@@ -74,7 +74,7 @@ html, body, #root, #root > div , #root > div > div {
     top: 112px;
     left: 0px;
     width: 100%;
-    max-height: calc(100% - 112px);
+    height: calc(100% - 112px);
     z-index: 500;
 }
 


### PR DESCRIPTION
## Overview

Fix for the bug Rob found. On opening and closing dev console (when dev console is at the bottom of the window), the diff map didn't resize to a 100% height. 

Connects #71 

## Testing Instructions

 * Add 2 layers
 * Enter diff mode
 * Open Chrome dev console at bottom of window
 * Close console and make sure the map resizes to take its place
