### PR TITLE
Add custom error routing for terraform

### DIFF
--- a/deployment/terraform/cdn.tf
+++ b/deployment/terraform/cdn.tf
@@ -57,6 +57,20 @@ resource "aws_cloudfront_distribution" "app" {
     max_ttl = 86400
   }
 
+  custom_error_response {
+    error_caching_min_ttl = "0"
+    error_code            = "403"
+    response_code         = "200"
+    response_page_path    = "/index.html"
+  }
+
+  custom_error_response {
+    error_caching_min_ttl = "0"
+    error_code            = "404"
+    response_code         = "200"
+    response_page_path    = "/index.html"
+  }
+
   logging_config {
     include_cookies = false
     bucket          = "${module.origin.logs_bucket}.s3.amazonaws.com"


### PR DESCRIPTION
## Overview

Add custom error routing for terraform so that `/g/:gistId` is routed back to `index.html`.

## Testing Instructions

 * Travis
