### PR TITLE
Specify favicon path in HTMLWebpackPlugin

### DIFF
--- a/src/app/template.html
+++ b/src/app/template.html
@@ -4,7 +4,6 @@
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta content="IE=edge" http-equiv="X-UA-Compatible">
-        <link rel="icon" type="image/png" href="/img/favicon.png">
         <title>TileJSON.io</title>
     </head>
     <body>

--- a/src/app/webpack.common.config.js
+++ b/src/app/webpack.common.config.js
@@ -33,6 +33,7 @@ module.exports = {
         new HtmlWebpackPlugin({
             title: 'Project Name',
             template: 'template.html',
+            favicon: 'img/favicon.png',
         }),
         new webpack.LoaderOptionsPlugin({
             options: {


### PR DESCRIPTION
## Overview

This makes the favicon get copied to the dist directory when the project
is built.

### Demo

![image](https://user-images.githubusercontent.com/1042475/36794268-e8812426-1c6d-11e8-8659-9c494dc460ea.png)

## Testing Instructions

- Run `./scripts/cibuild.sh`.
- Navigate to the `dist` directory.
- Run a local server (like `python SimpleHTTPServer 8001`).
- Visit the site and ensure the favicon loads.
