### PR TITLE
Use Netlify to authenticate into GitHub via TileJSON.io and share TileJSONs via private Gists

### DIFF
--- a/src/app/js/data/request.json
+++ b/src/app/js/data/request.json
@@ -1,5 +1,5 @@
 {
-    "description": "TileJSON.io",
+    "description": "TileJSON.io - ",
     "public": true,
     "files": {
         "index.html": {

--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -27,7 +27,7 @@ import {
     changeCurrentBaseLayer,
     resetShareValues,
     loadGist,
-    toggleGistNotFoundDialog,
+    toggleErrorDialog,
 } from './actions';
 import {
     appMuiTheme,
@@ -40,7 +40,7 @@ import {
 import AddLayerDialog from './AddLayerDialog';
 import ShareDialog from './ShareDialog';
 import ShareDescriptionDialog from './ShareDescriptionDialog';
-import GistNotFoundDialog from './GistNotFoundDialog';
+import ErrorDialog from './ErrorDialog';
 import NavBar from './NavBar';
 import SideBar from './SideBar';
 import DiffToolbar from './DiffToolbar';
@@ -313,8 +313,10 @@ class App extends Component {
             })
             .catch(() => {
                 this.props.history.push('/');
-                this.props.dispatch(toggleGistNotFoundDialog({
-                    gistNotFoundDialogOpen: true,
+                this.props.dispatch(toggleErrorDialog({
+                    errorDialogOpen: true,
+                    errorDialogTitle: 'Gist Not Found',
+                    errorDialogMessage: 'The GitHub Gist ID specified was not found.',
                 }));
             });
     }
@@ -376,7 +378,7 @@ class App extends Component {
                         <ShareDescriptionDialog
                             share={this.share}
                         />
-                        <GistNotFoundDialog />
+                        <ErrorDialog />
                     </Row>
                 </div>
             </MuiThemeProvider>

--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -213,6 +213,9 @@ class App extends Component {
     }
 
     share() {
+        if (this.props.githubToken === '') {
+            return;
+        }
         let tileJSON = this.props.tileJSON.slice(0);
         tileJSON = tileJSON.map((t, i) => {
             const newT = Object.assign({}, t);
@@ -237,12 +240,18 @@ class App extends Component {
         };
         if (this.props.shareTitle !== '') {
             info.title = this.props.shareTitle;
+            gistRequest.description += this.props.shareTitle;
         }
         if (this.props.shareDescription !== '') {
             info.description = this.props.shareDescription;
         }
         gistRequest.files['info.json'].content = JSON.stringify(info, null, '\t');
-        axios.post('https://api.github.com/gists', gistRequest)
+        const requestConfig = {
+            headers: {
+                Authorization: `Bearer ${this.props.githubToken}`,
+            },
+        };
+        axios.post('https://api.github.com/gists', gistRequest, requestConfig)
             .then((response) => {
                 this.props.dispatch(changeShareLink({
                     shareLink: `http://bl.ocks.org/d/${response.data.id}/`,
@@ -414,6 +423,7 @@ App.propTypes = {
     history: shape({
         push: func,
     }),
+    githubToken: string.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -16,7 +16,7 @@ import gistRequest from '../data/request.json';
 import {
     changeTileJson,
     clearScreen,
-    changeShareLink,
+    changeGistID,
     toggleShareSnackbarOpen,
     toggleErrorSnackbarOpen,
     toggleAddLayerDialog,
@@ -254,8 +254,8 @@ class App extends Component {
         };
         axios.post('https://api.github.com/gists', gistRequest, requestConfig)
             .then((response) => {
-                this.props.dispatch(changeShareLink({
-                    shareLink: `http://bl.ocks.org/d/${response.data.id}/`,
+                this.props.dispatch(changeGistID({
+                    gistID: response.data.id,
                 }));
                 this.props.dispatch(toggleShareSnackbarOpen({
                     shareSnackbarOpen: true,

--- a/src/app/js/src/App.jsx
+++ b/src/app/js/src/App.jsx
@@ -205,6 +205,7 @@ class App extends Component {
         this.layers = [
             this.layers[0],
         ];
+        this.props.history.push('/');
         this.props.dispatch(clearScreen());
         const tileJSONList = getDefaultTileJSON();
         if (document.getElementById('jsonTextarea')) {

--- a/src/app/js/src/ErrorDialog.jsx
+++ b/src/app/js/src/ErrorDialog.jsx
@@ -1,23 +1,25 @@
 import React, { Component } from 'react';
-import { bool, func } from 'prop-types';
+import { bool, func, string } from 'prop-types';
 import { connect } from 'react-redux';
 
 import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 
 import {
-    toggleGistNotFoundDialog,
+    toggleErrorDialog,
 } from './actions';
 
-class GistNotFoundDialog extends Component {
+class ErrorDialog extends Component {
     constructor(props) {
         super(props);
         this.closeGistNotFoundDialog = this.closeGistNotFoundDialog.bind(this);
     }
 
     closeGistNotFoundDialog() {
-        this.props.dispatch(toggleGistNotFoundDialog({
-            gistNotFoundDialogOpen: false,
+        this.props.dispatch(toggleErrorDialog({
+            errorDialogOpen: false,
+            errorDialogTitle: '',
+            errorDialogMessage: '',
         }));
     }
 
@@ -31,26 +33,28 @@ class GistNotFoundDialog extends Component {
         return (
             <div>
                 <Dialog
-                    title="Gist Not Found"
+                    title={this.props.errorDialogTitle}
                     actions={actions}
                     modal={false}
-                    open={this.props.gistNotFoundDialogOpen}
+                    open={this.props.errorDialogOpen}
                     onRequestClose={this.closeGistNotFoundDialog}
                 >
-                    <p>The GitHub Gist ID specified was not found.</p>
+                    <p>{this.props.errorDialogMessage}</p>
                 </Dialog>
             </div>
         );
     }
 }
 
-GistNotFoundDialog.propTypes = {
+ErrorDialog.propTypes = {
     dispatch: func.isRequired,
-    gistNotFoundDialogOpen: bool.isRequired,
+    errorDialogOpen: bool.isRequired,
+    errorDialogTitle: string.isRequired,
+    errorDialogMessage: string.isRequired,
 };
 
 function mapStateToProps(state) {
     return state.main;
 }
 
-export default connect(mapStateToProps)(GistNotFoundDialog);
+export default connect(mapStateToProps)(ErrorDialog);

--- a/src/app/js/src/ShareDescriptionDialog.jsx
+++ b/src/app/js/src/ShareDescriptionDialog.jsx
@@ -132,6 +132,10 @@ class ShareDescriptionDialog extends Component {
                     open={this.props.shareDescriptionDialogOpen}
                     onRequestClose={this.handleCancel}
                 >
+                    <p>
+                        To share this TileJSON,
+                        we will create a private Gist on your GitHub account.
+                    </p>
                     <TextField
                         name="shareTitle"
                         hintText="Map Title"

--- a/src/app/js/src/ShareDialog.jsx
+++ b/src/app/js/src/ShareDialog.jsx
@@ -12,6 +12,10 @@ import {
     toggleShareSnackbarOpen,
 } from './actions';
 
+import {
+    shareLink,
+} from './constants';
+
 class ShareDialog extends Component {
     constructor(props) {
         super(props);
@@ -31,7 +35,7 @@ class ShareDialog extends Component {
                 onClick={this.closeShareDialog}
             />,
             <CopyToClipboard
-                text={this.props.shareLink}
+                text={shareLink + this.props.gistID}
             >
                 <FlatButton
                     label="Copy URL"
@@ -50,7 +54,7 @@ class ShareDialog extends Component {
                 >
                     <TextField
                         name="shareUrl"
-                        value={this.props.shareLink}
+                        value={shareLink + this.props.gistID}
                         fullWidth
                     />
                 </Dialog>
@@ -62,7 +66,7 @@ class ShareDialog extends Component {
 ShareDialog.propTypes = {
     dispatch: func.isRequired,
     shareSnackbarOpen: bool.isRequired,
-    shareLink: string.isRequired,
+    gistID: string.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/SideBar.jsx
+++ b/src/app/js/src/SideBar.jsx
@@ -26,6 +26,8 @@ import {
     toggleTileJSONEditMode,
     toggleDiffMode,
     toggleShareDescriptionDialogOpen,
+    githubLogin,
+    githubLogout,
 } from './actions';
 import {
     map,
@@ -40,6 +42,8 @@ class SideBar extends Component {
         this.renderTileJSON = this.renderTileJSON.bind(this);
         this.openDiffMode = this.openDiffMode.bind(this);
         this.share = this.share.bind(this);
+        this.login = this.login.bind(this);
+        this.logout = this.logout.bind(this);
     }
 
     collapse() {
@@ -70,6 +74,16 @@ class SideBar extends Component {
         this.props.dispatch(toggleShareDescriptionDialogOpen({
             shareDescriptionDialogOpen: true,
         }));
+    }
+
+    login() {
+        this.props.dispatch(githubLogin({
+            githubToken: 'abc',
+        }));
+    }
+
+    logout() {
+        this.props.dispatch(githubLogout());
     }
 
     renderTileJSON() {
@@ -180,9 +194,29 @@ class SideBar extends Component {
                 </div>
             );
         }
+        const loginButton = (
+            <FlatButton
+                onClick={this.login}
+                label="Login"
+            />
+        );
+        const logoutButton = (
+            <FlatButton
+                onClick={this.logout}
+                label="Logout"
+            />
+        );
         return (
             <Col xs={4} id="menu">
-                <AppBar title="TileJSON.io" iconElementLeft={<IconButton onClick={this.collapse}><ExpandLess /></IconButton>} />
+                <AppBar
+                    title="TileJSON.io"
+                    iconElementLeft={
+                        <IconButton onClick={this.collapse}><ExpandLess /></IconButton>
+                    }
+                    iconElementRight={
+                        this.props.githubToken === '' ? loginButton : logoutButton
+                    }
+                />
                 <Grid fluid>
                     <br />
                     <Row>
@@ -239,6 +273,7 @@ SideBar.propTypes = {
     layers: arrayOf(object).isRequired,
     changeOpacity: func.isRequired,
     toggleVisibility: func.isRequired,
+    githubToken: string.isRequired,
 };
 
 function mapStateToProps(state) {

--- a/src/app/js/src/SideBar.jsx
+++ b/src/app/js/src/SideBar.jsx
@@ -32,6 +32,8 @@ import {
 import {
     map,
     getDefaultTileJSON,
+    authenticator,
+    authConfig,
 } from './constants';
 
 class SideBar extends Component {
@@ -77,9 +79,19 @@ class SideBar extends Component {
     }
 
     login() {
-        this.props.dispatch(githubLogin({
-            githubToken: 'abc',
-        }));
+        if (this.props.githubToken !== '') {
+            return;
+        }
+        authenticator.authenticate(authConfig, (err, data) => {
+            if (err) {
+                console.log(err);
+            } else {
+                console.log(data);
+                this.props.dispatch(githubLogin({
+                    githubToken: data.token,
+                }));
+            }
+        });
     }
 
     logout() {

--- a/src/app/js/src/SideBar.jsx
+++ b/src/app/js/src/SideBar.jsx
@@ -249,7 +249,10 @@ class SideBar extends Component {
                             <FlatButton
                                 onClick={this.share}
                                 label="Share"
-                                disabled={this.props.layers.length === 0}
+                                disabled={
+                                    this.props.layers.length === 0 ||
+                                    this.props.githubToken === ''
+                                }
                                 primary
                                 fullWidth
                             />

--- a/src/app/js/src/SideBar.jsx
+++ b/src/app/js/src/SideBar.jsx
@@ -28,6 +28,7 @@ import {
     toggleShareDescriptionDialogOpen,
     githubLogin,
     githubLogout,
+    toggleErrorDialog,
 } from './actions';
 import {
     map,
@@ -84,9 +85,12 @@ class SideBar extends Component {
         }
         authenticator.authenticate(authConfig, (err, data) => {
             if (err) {
-                console.log(err);
+                this.props.dispatch(toggleErrorDialog({
+                    errorDialogOpen: true,
+                    errorDialogTitle: 'GitHub Authentication Error',
+                    errorDialogMessage: 'Your GitHub authentication seems to have failed. Try again later.',
+                }));
             } else {
-                console.log(data);
                 this.props.dispatch(githubLogin({
                     githubToken: data.token,
                 }));

--- a/src/app/js/src/actions.js
+++ b/src/app/js/src/actions.js
@@ -1,7 +1,7 @@
 export const CHANGE_LAYER_NAME = 'CHANGE_LAYER_NAME';
 export const CHANGE_LAYER_URL = 'CHANGE_LAYER_URL';
 export const CHANGE_TILE_JSON = 'CHANGE_TILE_JSON';
-export const CHANGE_SHARE_LINK = 'CHANGE_SHARE_LINK';
+export const CHANGE_GIST_ID = 'CHANGE_GIST_ID';
 
 export const CLEAR_SCREEN = 'CLEAR_SCREEN';
 
@@ -78,9 +78,9 @@ export function clearScreen() {
     };
 }
 
-export function changeShareLink(payload) {
+export function changeGistID(payload) {
     return {
-        type: CHANGE_SHARE_LINK,
+        type: CHANGE_GIST_ID,
         payload,
     };
 }

--- a/src/app/js/src/actions.js
+++ b/src/app/js/src/actions.js
@@ -46,7 +46,7 @@ export const TOGGLE_BASE_LAYER_VISIBILITY = 'TOGGLE_BASE_LAYER_VISIBILITY';
 
 export const LOAD_GIST = 'LOAD_GIST';
 
-export const TOGGLE_GIST_NOT_FOUND_DIALOG = 'TOGGLE_GIST_NOT_FOUND_DIALOG';
+export const TOGGLE_ERROR_DIALOG = 'TOGGLE_ERROR_DIALOG';
 
 export const GITHUB_LOGIN = 'GITHUB_LOGIN';
 export const GITHUB_LOGOUT = 'GITHUB_LOGOUT';
@@ -295,9 +295,9 @@ export function loadGist(payload) {
     };
 }
 
-export function toggleGistNotFoundDialog(payload) {
+export function toggleErrorDialog(payload) {
     return {
-        type: TOGGLE_GIST_NOT_FOUND_DIALOG,
+        type: TOGGLE_ERROR_DIALOG,
         payload,
     };
 }

--- a/src/app/js/src/actions.js
+++ b/src/app/js/src/actions.js
@@ -48,6 +48,9 @@ export const LOAD_GIST = 'LOAD_GIST';
 
 export const TOGGLE_GIST_NOT_FOUND_DIALOG = 'TOGGLE_GIST_NOT_FOUND_DIALOG';
 
+export const GITHUB_LOGIN = 'GITHUB_LOGIN';
+export const GITHUB_LOGOUT = 'GITHUB_LOGOUT';
+
 export function changeLayerName(payload) {
     return {
         type: CHANGE_LAYER_NAME,
@@ -296,5 +299,18 @@ export function toggleGistNotFoundDialog(payload) {
     return {
         type: TOGGLE_GIST_NOT_FOUND_DIALOG,
         payload,
+    };
+}
+
+export function githubLogin(payload) {
+    return {
+        type: GITHUB_LOGIN,
+        payload,
+    };
+}
+
+export function githubLogout() {
+    return {
+        type: GITHUB_LOGOUT,
     };
 }

--- a/src/app/js/src/constants.js
+++ b/src/app/js/src/constants.js
@@ -98,3 +98,5 @@ export const authConfig = {
     provider: 'github',
     scope: 'gist,read:user',
 };
+
+export const shareLink = 'http://bl.ocks.org/d/';

--- a/src/app/js/src/constants.js
+++ b/src/app/js/src/constants.js
@@ -4,6 +4,7 @@ import Attribution from 'ol/attribution';
 import Map from 'ol/map';
 import View from 'ol/view';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
+import Netlify from 'netlify-auth-providers';
 
 export const baseLayers = [
     {
@@ -91,3 +92,9 @@ export const defaultShareDiff = false;
 export const defaultDefaultToDiff = false;
 
 export const exampleURL = 'https://a.tiles.azavea.com/nlcd/{z}/{x}/{y}.png';
+
+export const authenticator = new Netlify({ site_id: '55b9f51c-02f8-4555-a1e9-320fca59bcc5' });
+export const authConfig = {
+    provider: 'github',
+    scope: 'gist,read:user',
+};

--- a/src/app/js/src/reducers.js
+++ b/src/app/js/src/reducers.js
@@ -37,6 +37,8 @@ import {
     TOGGLE_BASE_LAYER_VISIBILITY,
     LOAD_GIST,
     TOGGLE_GIST_NOT_FOUND_DIALOG,
+    GITHUB_LOGIN,
+    GITHUB_LOGOUT,
 } from './actions';
 
 import {
@@ -80,6 +82,7 @@ const initialState = {
     shareDescriptionDialogOpen: false,
     baseLayerVisible: true,
     gistNotFoundDialogOpen: false,
+    githubToken: '',
 };
 
 function mainReducer(state = initialState, action) {
@@ -363,6 +366,14 @@ function mainReducer(state = initialState, action) {
         case TOGGLE_GIST_NOT_FOUND_DIALOG:
             return Object.assign({}, state, {
                 gistNotFoundDialogOpen: action.payload.gistNotFoundDialogOpen,
+            });
+        case GITHUB_LOGIN:
+            return Object.assign({}, state, {
+                githubToken: action.payload.githubToken,
+            });
+        case GITHUB_LOGOUT:
+            return Object.assign({}, state, {
+                githubToken: '',
             });
         default:
             return state;

--- a/src/app/js/src/reducers.js
+++ b/src/app/js/src/reducers.js
@@ -5,7 +5,7 @@ import {
     CHANGE_LAYER_URL,
     CHANGE_TILE_JSON,
     CLEAR_SCREEN,
-    CHANGE_SHARE_LINK,
+    CHANGE_GIST_ID,
     TOGGLE_TILE_JSON_EDIT_MODE,
     CHANGE_TILE_JSON_PARSE_ERROR,
     TOGGLE_SHARE_SNACKBAR_OPEN,
@@ -58,7 +58,7 @@ const initialState = {
     tileJSONString: JSON.stringify(getDefaultTileJSON(), null, '\t'),
     tileJSONEditMode: false,
     tileJSONParseError: '',
-    shareLink: '',
+    gistID: '',
     shareSnackbarOpen: false,
     errorSnackbarOpen: false,
     isCollapsed: false,
@@ -107,7 +107,7 @@ function mainReducer(state = initialState, action) {
             return Object.assign({}, state, {
                 tileJSON: getDefaultTileJSON(),
                 tileJSONString: JSON.stringify(getDefaultTileJSON(), null, '\t'),
-                shareLink: '',
+                gistID: '',
                 url: '',
                 name: '',
                 tileJSONParseError: '',
@@ -135,9 +135,9 @@ function mainReducer(state = initialState, action) {
                 errorDialogTitle: '',
                 errorDialogMessage: '',
             });
-        case CHANGE_SHARE_LINK:
+        case CHANGE_GIST_ID:
             return Object.assign({}, state, {
-                shareLink: action.payload.shareLink,
+                gistID: action.payload.gistID,
             });
         case TOGGLE_TILE_JSON_EDIT_MODE:
             return Object.assign({}, state, {

--- a/src/app/js/src/reducers.js
+++ b/src/app/js/src/reducers.js
@@ -36,7 +36,7 @@ import {
     TOGGLE_LAYER_VISIBILITY,
     TOGGLE_BASE_LAYER_VISIBILITY,
     LOAD_GIST,
-    TOGGLE_GIST_NOT_FOUND_DIALOG,
+    TOGGLE_ERROR_DIALOG,
     GITHUB_LOGIN,
     GITHUB_LOGOUT,
 } from './actions';
@@ -81,7 +81,9 @@ const initialState = {
     defaultToDiff: defaultDefaultToDiff,
     shareDescriptionDialogOpen: false,
     baseLayerVisible: true,
-    gistNotFoundDialogOpen: false,
+    errorDialogOpen: false,
+    errorDialogTitle: '',
+    errorDialogMessage: '',
     githubToken: '',
 };
 
@@ -129,7 +131,9 @@ function mainReducer(state = initialState, action) {
                 defaultToDiff: defaultDefaultToDiff,
                 shareDescriptionDialogOpen: false,
                 baseLayerVisible: true,
-                gistNotFoundDialogOpen: false,
+                errorDialogOpen: false,
+                errorDialogTitle: '',
+                errorDialogMessage: '',
             });
         case CHANGE_SHARE_LINK:
             return Object.assign({}, state, {
@@ -363,9 +367,11 @@ function mainReducer(state = initialState, action) {
                     true : action.payload.infoJSON.shareBase,
             });
         }
-        case TOGGLE_GIST_NOT_FOUND_DIALOG:
+        case TOGGLE_ERROR_DIALOG:
             return Object.assign({}, state, {
-                gistNotFoundDialogOpen: action.payload.gistNotFoundDialogOpen,
+                errorDialogOpen: action.payload.errorDialogOpen,
+                errorDialogTitle: action.payload.errorDialogTitle,
+                errorDialogMessage: action.payload.errorDialogMessage,
             });
         case GITHUB_LOGIN:
             return Object.assign({}, state, {

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -22,6 +22,7 @@
     "isomorphic-fetch": "2.2.1",
     "leaflet": "1.2.0",
     "material-ui": "0.19.4",
+    "netlify-auth-providers": "1.0.0-alpha5",
     "ol": "4.3.3",
     "prop-types": "15.5.10",
     "react": "15.6.1",

--- a/src/app/yarn.lock
+++ b/src/app/yarn.lock
@@ -4291,6 +4291,11 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
+netlify-auth-providers@1.0.0-alpha5:
+  version "1.0.0-alpha5"
+  resolved "https://registry.yarnpkg.com/netlify-auth-providers/-/netlify-auth-providers-1.0.0-alpha5.tgz#f0ce642fe5534f04a1d539ca847c907dd20819c8"
+  integrity sha512-V4tqW60NEOYdd7QUWotB+XeMbw/kayi4Sbm67hSMWibXHG7xiRUp6+VEB8CmBt7/kb3HTw7+mQSwF7YR9hRaSQ==
+
 no-case@^2.2.0:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.2.tgz#60b813396be39b3f1288a4c1ed5d1e7d28b464ac"


### PR DESCRIPTION
## Overview

This PR adds ability to authenticate via GitHub and shares maps by creating private Gists on the user's behalf. Specifically, it does the following things:
 - Uses Netlify's authentication providers feature to authenticate to GitHub. 
 - Refactors the app to make the component `GistNotFoundDialog` generic, names it `ErrorDialog`, and uses `ErrorDialog` if the authentication fails.
 - Adds a message to the share description dialog about gist creation on user's behalf.
 - Allows users to share TileJSONs via private Gists.
 - Minor refactoring.

### Notes

Netlify makes it so that you don't need to change the settings on the GitHub application for the callback URL and handles everything so I don't need extra logic to handle the first step of the auth on the React code (unlike the Glitch solution).

The code actual shared link doesn't work. That's a bug and an issue has been created.


## Testing Instructions

 * Test on localhost and Netlify PR site
 * `Login` should log you in via GitHub
 * `Logout` should log you out once you're in
 * Add a map layer before logging in. See that the `Share` button is disabled.
 * Login and try to share a map. Ensure that you get a link and that your GitHub Gists have this new Gist created by the app.

Closes [#161933880](https://www.pivotaltracker.com/story/show/161933880) and [#161934073](https://www.pivotaltracker.com/story/show/161934073)
