### PR TITLE
Add upgrade-insecure-requests to CSP

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -21,7 +21,7 @@
 [[headers]]
   for = "/*"
 [headers.values]
-  Content-Security-Policy = "default-src https: blob: data: 'unsafe-inline' 'unsafe-eval'"
+  Content-Security-Policy = "upgrade-insecure-requests; default-src https: blob: data: 'unsafe-inline' 'unsafe-eval';"
   X-Frame-Options = "DENY"
   X-XSS-Protection = "1; mode=block"
   X-Content-Type-Options = "nosniff"


### PR DESCRIPTION
## Overview

HTTP tile URLs cannot be supported because `tilejson.io` is only served over HTTPS. Our current `Content-Security-Policy` blocks HTTP tile requests from being attempted (no `http:` in `default-src` or `img-src`), but when the policy is modified to allow them, HTTP tile requests are blocked by the browser's mixed content blocking policy.

In an effort to adjust on-the-fly, `upgrade-insecure-requests` was added so that a tile URL of:

```
http://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png
```

Would automatically be upgraded to:

```
https://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png
```

(The latter URL uses `https`.)

Fixes https://github.com/azavea/tilejson.io/issues/102

### Notes

See: https://developers.google.com/web/fundamentals/security/prevent-mixed-content/what-is-mixed-content

## Testing Instructions

- Navigate to the `deploy/netlify` preview for this PR
- Add `http://a.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png` as a tile layer
- View requests in the Network pane of your browser's inspector tools; ensure requests to `a.basemaps.cartocdn.com` are being made over HTTPS